### PR TITLE
Use docker:// scheme for installing docker images

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -149,19 +149,6 @@ func saveToDisk(f *providers.File, path string, overwrite bool) error {
 
 	var outputFile = io.MultiReader(&buf, f.Data)
 
-	if t != matchers.TypeElf && t != matchers.TypeGz {
-		// if its not elf or gz then its an executable text file
-		// that needs to be written as is
-		file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0766)
-		if err != nil {
-			return err
-		}
-		defer file.Close()
-
-		_, err = io.Copy(file, outputFile)
-		return err
-	}
-
 	if t == matchers.TypeGz {
 		fileName, file, err := processTarGz(outputFile)
 		if err != nil {

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -149,6 +149,12 @@ func saveToDisk(f *providers.File, path string, overwrite bool) error {
 
 	var outputFile = io.MultiReader(&buf, f.Data)
 
+	// TODO: validating the type of the file will eventually be
+	// handled by each provider
+	// if t != matchers.TypeElf && t != matchers.TypeGz {
+	// 	return fmt.Errorf("File type [%v] not supported", t)
+	// }
+
 	if t == matchers.TypeGz {
 		fileName, file, err := processTarGz(outputFile)
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Microsoft/go-winio v0.4.14 // indirect
 	github.com/WeiZhang555/tabwriter v0.0.0-20200115015932-e5c45f4da38d
 	github.com/apex/log v1.1.4
-	github.com/docker/distribution v2.7.1+incompatible // indirect
+	github.com/docker/distribution v2.7.1+incompatible
 	github.com/docker/docker v1.13.1
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.4.0 // indirect

--- a/pkg/providers/docker.go
+++ b/pkg/providers/docker.go
@@ -15,6 +15,10 @@ import (
 )
 
 const (
+	// TODO: this probably won't work on windows so we might need how we mount
+	// TODO: there might be a way were users can configure a template for the
+	// actual execution since some CLIs require some other folders to be mounted
+	// or networks to be shared
 	sh = `docker run --rm -i -t -v ${PWD}:/tmp/cmd -w /tmp/cmd %s:%s "$@"`
 )
 

--- a/pkg/providers/docker_test.go
+++ b/pkg/providers/docker_test.go
@@ -1,31 +1,33 @@
 package providers
 
-import "testing"
+import (
+	"testing"
+)
 
-func TestGetImageDesc(t *testing.T) {
+func TestParseImage(t *testing.T) {
 	cases := []struct {
-		name            string
-		path            string
-		expectedOwner   string
-		expectedName    string
-		expectedVersion string
+		name                      string
+		imageURL                  string
+		expectedRepo, expectedTag string
+		withErr                   bool
 	}{
-		{"no owner no version", "/alpine", "library", "alpine", "latest"},
-		{"no owner with version", "/alpine:3.0.9", "library", "alpine", "3.0.9"},
-		{"with owner and no version", "/hashicorp/terraform", "hashicorp", "terraform", "latest"},
-		{"with owner with version", "/hashicorp/terraform:light", "hashicorp", "terraform", "light"},
+		{name: "no host, no version", imageURL: "postgres", expectedRepo: "docker.io/library/postgres", expectedTag: "latest"},
+		{name: "no host, with version", imageURL: "postgres:1.2.3", expectedRepo: "docker.io/library/postgres", expectedTag: "1.2.3"},
+		{name: "with host, no version", imageURL: "quay.io/calico/node", expectedRepo: "quay.io/calico/node", expectedTag: "latest"},
+		{name: "with host, with version", imageURL: "quay.io/calico/node:1.2.3", expectedRepo: "quay.io/calico/node", expectedTag: "1.2.3"},
+		{name: "no host, with version and owner", imageURL: "hashicorp/terraform:1.2.3", expectedRepo: "docker.io/hashicorp/terraform", expectedTag: "1.2.3"},
 	}
 
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
-			owner, name, version := getImageDesc(test.path)
+			repo, tag, err := parseImage(test.imageURL)
 			switch {
-			case test.expectedOwner != owner:
-				t.Errorf("expected owner was %s got %s", test.expectedOwner, owner)
-			case test.expectedName != name:
-				t.Errorf("expected name was %s got %s", test.expectedName, name)
-			case test.expectedVersion != version:
-				t.Errorf("expected version was %s got %s", test.expectedVersion, version)
+			case test.expectedRepo != repo:
+				t.Errorf("expected repo was %s, got %s", test.expectedRepo, repo)
+			case test.expectedTag != tag:
+				t.Errorf("expected tag was %s, got %s", test.expectedTag, tag)
+			case test.withErr != (err != nil):
+				t.Errorf("expected err != nil to be %v", test.withErr)
 			}
 		})
 	}

--- a/pkg/providers/providers.go
+++ b/pkg/providers/providers.go
@@ -24,9 +24,15 @@ type Provider interface {
 	GetLatestVersion(string) (string, string, error)
 }
 
-var httpUrlPrefix = regexp.MustCompile("^https?://")
+var (
+	httpUrlPrefix   = regexp.MustCompile("^https?://")
+	dockerUrlPrefix = regexp.MustCompile("^docker://")
+)
 
 func New(u string) (Provider, error) {
+	if dockerUrlPrefix.MatchString(u) {
+		return newDocker(u)
+	}
 	if !httpUrlPrefix.MatchString(u) {
 		u = fmt.Sprintf("https://%s", u)
 	}
@@ -39,10 +45,6 @@ func New(u string) (Provider, error) {
 
 	if strings.Contains(purl.Host, "github") {
 		return newGitHub(purl)
-	}
-
-	if strings.Contains(purl.Host, "hub.docker.com") || strings.Contains(purl.Host, "docker.io") {
-		return newDocker(purl)
 	}
 
 	return nil, fmt.Errorf("Can't find provider for url %s", u)


### PR DESCRIPTION
# Description
Docker images live in many different registries, bin needs to support downloading from all of them. For starter, we need to differentiate between github, docker or any other provider. To do this, when trying to install docker images users need to specify the `docker://` scheme:
```
bin install docker://postgres
```
We also need to support tags so that users can do:
```
bin install docker://hashicorp/terraform:light
```

Closes #1 