### PR TITLE
Reorder replacements to match osName+archName first

### DIFF
--- a/pkg/providers/github.go
+++ b/pkg/providers/github.go
@@ -180,8 +180,6 @@ func sanitizeName(name, version string) string {
 	// generate the replacements? IDK.
 	firstPass := true
 	for _, osName := range config.GetOS() {
-		replacements = append(replacements, "_"+osName, "")
-		replacements = append(replacements, "-"+osName, "")
 		for _, archName := range config.GetArch() {
 			replacements = append(replacements, "_"+osName+archName, "")
 			replacements = append(replacements, "-"+osName+archName, "")
@@ -191,6 +189,10 @@ func sanitizeName(name, version string) string {
 				replacements = append(replacements, "-"+archName, "")
 			}
 		}
+
+		replacements = append(replacements, "_"+osName, "")
+		replacements = append(replacements, "-"+osName, "")
+
 		firstPass = false
 
 	}


### PR DESCRIPTION
db7ff1addb3fdd975e63f7ce23fff57a703d3ece introduced a regression wrt. #12 (PR #13). This reordering ensures the combination of OS + Arch without delimiters is matched first.