### PR TITLE
Skip invalid semantic versions in HashiCorp provider

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect
-	github.com/pkg/errors v0.9.1
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/sirupsen/logrus v1.6.0 // indirect
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5 // indirect
@@ -35,7 +35,6 @@ require (
 	github.com/xanzy/go-gitlab v0.33.0
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8
 	github.com/yuin/goldmark v1.2.0
-	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/net v0.0.0-20200625001655-4c5254603344 // indirect
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd

--- a/pkg/providers/hashicorp.go
+++ b/pkg/providers/hashicorp.go
@@ -139,7 +139,8 @@ func (g *hashiCorp) GetLatestVersion() (string, string, error) {
 	for _, version := range releases.Versions {
 		sv, err := semver.NewVersion(version.Version)
 		if err != nil {
-			return "", "", err
+			log.Debugf("unable to parse %q as a semantic version: %+v", version.Version, err)
+			continue
 		}
 		if sv.PreRelease == "" && sv.Metadata == "" {
 			svs = append(svs, sv)


### PR DESCRIPTION
Closes #38.

Sample output (with `--force` as I already have it installed):

```console
$ ./bin install --force https://releases.hashicorp.com/vault
   • Starting download of https://releases.hashicorp.com/vault/1.5.5/vault_1.5.5_linux_amd64.zip
48.85 MiB / 48.85 MiB [--------------------------------------------------------------------------------------------------------------------------------] 100.00% 55.90 MiB p/s 1s
   • Copying for vault@1.5.5 into /home/<redacted>/bin/vault
   • Done installing vault 1.5.5
```

With `--debug` to show messages about invalid semantic versions:

```console
$ ./bin --debug install --force https://releases.hashicorp.com/vault
   • debug logs enabled       
   • Download path set to /home/<redacted>/bin
   • Getting latest release for vault
   • unable to parse "1.4.5.1+ent" as a semantic version: strconv.ParseInt: parsing "5.1": invalid syntax
   • unable to parse "1.4.7.1+ent.hsm" as a semantic version: strconv.ParseInt: parsing "7.1": invalid syntax
   • unable to parse "1.3.9.1+ent.hsm" as a semantic version: strconv.ParseInt: parsing "9.1": invalid syntax
   • unable to parse "1.3.9.1+ent" as a semantic version: strconv.ParseInt: parsing "9.1": invalid syntax
   • unable to parse "1.5.2.1+ent.hsm" as a semantic version: strconv.ParseInt: parsing "2.1": invalid syntax
   • unable to parse "1.5.2.1+ent" as a semantic version: strconv.ParseInt: parsing "2.1": invalid syntax
   • unable to parse "1.2.6.1+ent.hsm" as a semantic version: strconv.ParseInt: parsing "6.1": invalid syntax
   • unable to parse "1.2.6.1+ent" as a semantic version: strconv.ParseInt: parsing "6.1": invalid syntax
   • unable to parse "1.4.7.1+ent" as a semantic version: strconv.ParseInt: parsing "7.1": invalid syntax
   • unable to parse "1.4.5.1+ent.hsm" as a semantic version: strconv.ParseInt: parsing "5.1": invalid syntax
   • Removing vault_1.5.5_windows_amd64.zip with score 22 lower than 42
   • Removing vault_1.5.5_windows_386.zip with score 2 lower than 42
   • Removing vault_1.5.5_solaris_amd64.zip with score 22 lower than 42
   • Removing vault_1.5.5_openbsd_amd64.zip with score 22 lower than 42
   • Removing vault_1.5.5_openbsd_386.zip with score 2 lower than 42
   • Removing vault_1.5.5_netbsd_amd64.zip with score 22 lower than 42
   • Removing vault_1.5.5_netbsd_386.zip with score 2 lower than 42
   • Removing vault_1.5.5_linux_arm64.zip with score 32 lower than 42
   • Removing vault_1.5.5_linux_arm.zip with score 22 lower than 42
   • Keeping vault_1.5.5_linux_amd64.zip (URL https://releases.hashicorp.com/vault/1.5.5/vault_1.5.5_linux_amd64.zip) with highest score 42
   • Removing vault_1.5.5_linux_386.zip with score 22 lower than 42
   • Removing vault_1.5.5_freebsd_arm.zip with score 2 lower than 42
   • Removing vault_1.5.5_freebsd_amd64.zip with score 22 lower than 42
   • Removing vault_1.5.5_freebsd_386.zip with score 2 lower than 42
   • Removing vault_1.5.5_darwin_amd64.zip with score 22 lower than 42
   • Removing vault_1.5.5_darwin_386.zip with score 2 lower than 42
   • Checking binary from https://releases.hashicorp.com/vault/1.5.5/vault_1.5.5_linux_amd64.zip
   • Starting download of https://releases.hashicorp.com/vault/1.5.5/vault_1.5.5_linux_amd64.zip
48.85 MiB / 48.85 MiB [--------------------------------------------------------------------------------------------------------------------------------] 100.00% 39.25 MiB p/s 2s
   • Copying for vault@1.5.5 into /home/<redacted>/bin/vault
   • Done installing vault 1.5.5
```