### PR TITLE
Gitlab generic packages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/testify v1.6.1 // indirect
-	github.com/xanzy/go-gitlab v0.33.0
+	github.com/xanzy/go-gitlab v0.44.0
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8
 	github.com/yuin/goldmark v1.2.0
 	golang.org/x/net v0.0.0-20200625001655-4c5254603344 // indirect

--- a/go.sum
+++ b/go.sum
@@ -192,8 +192,8 @@ github.com/tj/go-kinesis v0.0.0-20171128231115-08b17f58cb1b/go.mod h1:/yhzCV0xPf
 github.com/tj/go-spin v1.1.0/go.mod h1:Mg1mzmePZm4dva8Qz60H2lHwmJ2loum4VIrLgVnKwh4=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
-github.com/xanzy/go-gitlab v0.33.0 h1:MUJZknbLhVXSFzBA5eqGGhQ2yHSu8tPbGBPeB3sN4B0=
-github.com/xanzy/go-gitlab v0.33.0/go.mod h1:sPLojNBn68fMUWSxIJtdVVIP8uSBYqesTfDUseX11Ug=
+github.com/xanzy/go-gitlab v0.44.0 h1:cEiGhqu7EpFGuei2a2etAwB+x6403E5CvpLn35y+GPs=
+github.com/xanzy/go-gitlab v0.44.0/go.mod h1:sPLojNBn68fMUWSxIJtdVVIP8uSBYqesTfDUseX11Ug=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofmx9yWTog9BfvIu0q41lo=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/pkg/assets/assets.go
+++ b/pkg/assets/assets.go
@@ -81,7 +81,7 @@ func FilterAssets(repoName string, as []*Asset) (*FilteredAsset, error) {
 	for _, os := range resolver.GetOS() {
 		scores[os] = 10
 	}
-	for _, arch := range config.GetArch() {
+	for _, arch := range resolver.GetArch() {
 		scores[arch] = 5
 	}
 	scoreKeys := []string{}
@@ -162,7 +162,7 @@ func SanitizeName(name, version string) string {
 	// generate the replacements? IDK.
 	firstPass := true
 	for _, osName := range resolver.GetOS() {
-		for _, archName := range config.GetArch() {
+		for _, archName := range resolver.GetArch() {
 			replacements = append(replacements, "_"+osName+archName, "")
 			replacements = append(replacements, "-"+osName+archName, "")
 			replacements = append(replacements, "."+osName+archName, "")

--- a/pkg/assets/assets.go
+++ b/pkg/assets/assets.go
@@ -104,6 +104,7 @@ func FilterAssets(repoName string, as []*Asset) (*FilteredAsset, error) {
 				}
 				if candidateScore > highestScoreForAsset {
 					highestScoreForAsset = candidateScore
+					gf.Name = candidate
 					gf.score = candidateScore
 				}
 			}

--- a/pkg/assets/assets.go
+++ b/pkg/assets/assets.go
@@ -121,7 +121,7 @@ func FilterAssets(repoName string, as []*Asset) (*FilteredAsset, error) {
 	}
 	for i := len(matches) - 1; i >= 0; i-- {
 		if matches[i].score < highestAssetScore {
-			log.Debugf("Removing %v with score %v lower than %v", matches[i].Name, matches[i].score, highestAssetScore)
+			log.Debugf("Removing %v (URL %v) with score %v lower than %v", matches[i].Name, matches[i].URL, matches[i].score, highestAssetScore)
 			matches = append(matches[:i], matches[i+1:]...)
 		} else {
 			log.Debugf("Keeping %v (URL %v) with highest score %v", matches[i].Name, matches[i].URL, matches[i].score)

--- a/pkg/assets/assets.go
+++ b/pkg/assets/assets.go
@@ -91,22 +91,19 @@ func FilterAssets(repoName string, as []*Asset) (*FilteredAsset, error) {
 	for _, a := range as {
 		lowerName := strings.ToLower(a.Name)
 		lowerURLPathBasename := path.Base(strings.ToLower(a.URL))
-		filetype.GetType(lowerName)
 		highestScoreForAsset := 0
-		gf := &FilteredAsset{RepoName: repoName, Name: a.Name, URL: a.URL, score: 0}
+		gf := &FilteredAsset{RepoName: repoName, Name: a.Name, DisplayName: a.DisplayName, URL: a.URL, score: 0}
 		for _, candidate := range []string{lowerName, lowerURLPathBasename} {
 			candidateScore := 0
 			if bstrings.ContainsAny(candidate, scoreKeys) &&
 				isSupportedExt(candidate) {
 				for toMatch, score := range scores {
-					if strings.Contains(candidate, toMatch) {
+					if strings.Contains(candidate, strings.ToLower(toMatch)) {
 						candidateScore += score
 					}
 				}
 				if candidateScore > highestScoreForAsset {
 					highestScoreForAsset = candidateScore
-					gf.Name = candidate
-					gf.DisplayName = a.DisplayName
 					gf.score = candidateScore
 				}
 			}

--- a/pkg/assets/assets_test.go
+++ b/pkg/assets/assets_test.go
@@ -21,17 +21,17 @@ func TestSanitizeName(t *testing.T) {
 	linuxAMDResolver := &mockOSResolver{OS: []string{"linux"}, Arch: []string{"amd64"}}
 	windowsAMDResolver := &mockOSResolver{OS: []string{"windows"}, Arch: []string{"amd64"}}
 	cases := []struct {
-		in  string
-		v   string
-		out string
+		in       string
+		v        string
+		out      string
 		resolver platformResolver
 	}{
-		{"bin_amd64_linux", "v0.0.1", "bin",linuxAMDResolver},
-		{"bin_0.0.1_amd64_linux", "0.0.1", "bin",linuxAMDResolver},
-		{"bin_0.0.1_amd64_linux", "v0.0.1", "bin",linuxAMDResolver},
-		{"gitlab-runner-linux-amd64", "v13.2.1", "gitlab-runner",linuxAMDResolver},
-		{"jq-linux64", "jq-1.5", "jq",linuxAMDResolver},
-		{"bin_0.0.1_Windows_x86_64.exe","0.0.1","bin.exe",windowsAMDResolver},
+		{"bin_amd64_linux", "v0.0.1", "bin", linuxAMDResolver},
+		{"bin_0.0.1_amd64_linux", "0.0.1", "bin", linuxAMDResolver},
+		{"bin_0.0.1_amd64_linux", "v0.0.1", "bin", linuxAMDResolver},
+		{"gitlab-runner-linux-amd64", "v13.2.1", "gitlab-runner", linuxAMDResolver},
+		{"jq-linux64", "jq-1.5", "jq", linuxAMDResolver},
+		{"bin_0.0.1_Windows_x86_64.exe", "0.0.1", "bin.exe", windowsAMDResolver},
 	}
 
 	for _, c := range cases {
@@ -44,8 +44,8 @@ func TestSanitizeName(t *testing.T) {
 }
 
 func TestFilterAssets(t *testing.T) {
-	linuxAMDResolver := &mockOSResolver{OS: []string{"linux"}, Arch: []string{"amd64"}}
-	windowsAMDResolver := &mockOSResolver{OS: []string{"windows"}, Arch: []string{"amd64"}}
+	linuxAMDResolver := &mockOSResolver{OS: []string{"linux"}, Arch: []string{"amd64", "x86_64", "64"}}
+	windowsAMDResolver := &mockOSResolver{OS: []string{"windows"}, Arch: []string{"amd64", "x86_64", "64"}}
 	type args struct {
 		repoName string
 		as       []*Asset

--- a/pkg/assets/assets_test.go
+++ b/pkg/assets/assets_test.go
@@ -18,8 +18,8 @@ func (m *mockOSResolver) GetArch() []string {
 }
 
 func TestSanitizeName(t *testing.T) {
-	linuxAMDResolver := &mockOSResolver{OS: []string{"linux"}, Arch: []string{"amd64"}}
-	windowsAMDResolver := &mockOSResolver{OS: []string{"windows"}, Arch: []string{"amd64"}}
+	linuxAMDResolver := &mockOSResolver{OS: []string{"linux"}, Arch: []string{"amd64", "x86_64", "64"}}
+	windowsAMDResolver := &mockOSResolver{OS: []string{"windows"}, Arch: []string{"amd64", "x86_64", "64"}}
 	cases := []struct {
 		in       string
 		v        string
@@ -90,6 +90,9 @@ func TestFilterAssets(t *testing.T) {
 			{Name: "bin_0.1.0_Linux_x86_64", URL: "https://github.com/marcosnils/bin/releases/download/v0.0.1/bin_0.1.0_Linux_x86_64"},
 			{Name: "bin_0.1.0_Darwin_x86_64", URL: "https://github.com/marcosnils/bin/releases/download/v0.0.1/bin_0.1.0_Darwin_x86_64"},
 		}}, "bin_0.0.1_windows_x86_64.exe", windowsAMDResolver},
+		{args{"tezos", []*Asset{
+			{Name: "x86_64-linux-tezos-binaries.tar.gz", URL: "https://gitlab.com/api/v4/projects/3836952/packages/generic/tezos/8.2.0/x86_64-linux-tezos-binaries.tar.gz"},
+		}}, "x86_64-linux-tezos-binaries.tar.gz", linuxAMDResolver},
 	}
 
 	for _, c := range cases {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -123,7 +123,6 @@ func GetArch() []string {
 		//Adding x86_64 manually since the uname syscall (man 2 uname)
 		//is not implemented in all systems
 		res = append(res, "x86_64")
-		res = append(res, "amd64")
 		res = append(res, "64")
 	}
 	return res

--- a/pkg/providers/gitlab.go
+++ b/pkg/providers/gitlab.go
@@ -104,7 +104,7 @@ func (g *gitLab) Fetch() (*File, error) {
 		return nil, err
 	}
 	projectUploadsURL := fmt.Sprintf("%s/uploads/", project.WebURL)
-	projectIsPublic := project.Visibility == gitlab.PublicVisibility
+	projectIsPublic := g.token == "" || project.Visibility == gitlab.PublicVisibility
 	log.Debugf("Project is public: %v", projectIsPublic)
 	for _, link := range release.Assets.Links {
 		if projectIsPublic || !strings.HasPrefix(link.URL, projectUploadsURL) {

--- a/pkg/providers/gitlab.go
+++ b/pkg/providers/gitlab.go
@@ -66,35 +66,45 @@ func (g *gitLab) Fetch() (*File, error) {
 	candidates := []*assets.Asset{}
 	candidateURLs := map[string]struct{}{}
 
-	packages, _, err := g.client.Packages.ListProjectPackages(projectPath, &gitlab.ListProjectPackagesOptions{})
+	packages, _, err := g.client.Packages.ListProjectPackages(projectPath, &gitlab.ListProjectPackagesOptions{
+		OrderBy: gitlab.String("version"),
+		Sort:    gitlab.String("desc"),
+	})
 	if err != nil {
 		return nil, err
 	}
+	tagVersion := strings.TrimPrefix(release.TagName, "v")
 	for _, v := range packages {
-		if fmt.Sprintf("v%s", v.Version) == release.TagName {
-			packageFiles, _, err := g.client.Packages.ListPackageFiles(projectPath, v.ID, &gitlab.ListPackageFilesOptions{})
-			if err != nil {
-				return nil, err
-			}
-			for _, f := range packageFiles {
-				assetURL := fmt.Sprintf("%sprojects/%s/packages/%s/%s/%s/%s",
-					g.client.BaseURL().String(),
-					url.PathEscape(projectPath),
-					v.PackageType,
-					v.Name,
-					v.Version,
-					f.FileName,
-				)
-				if _, exists := candidateURLs[assetURL]; !exists {
-					asset := &assets.Asset{
-						Name:        v.Name,
-						DisplayName: fmt.Sprintf("%s (%s package)", f.FileName, v.PackageType),
-						URL:         assetURL,
-					}
-					candidates = append(candidates, asset)
-					log.Debugf("Adding %s with URL %s", asset.Name, asset.URL)
+		if strings.TrimPrefix(v.Version, "v") == tagVersion {
+			totalPages := -1
+			for page := 1; page != totalPages; page++ {
+				packageFiles, resp, err := g.client.Packages.ListPackageFiles(projectPath, v.ID, &gitlab.ListPackageFilesOptions{
+					Page: page,
+				})
+				if err != nil {
+					return nil, err
 				}
-				candidateURLs[assetURL] = struct{}{}
+				totalPages = resp.TotalPages
+				for _, f := range packageFiles {
+					assetURL := fmt.Sprintf("%sprojects/%s/packages/%s/%s/%s/%s",
+						g.client.BaseURL().String(),
+						url.PathEscape(projectPath),
+						v.PackageType,
+						v.Name,
+						v.Version,
+						f.FileName,
+					)
+					if _, exists := candidateURLs[assetURL]; !exists {
+						asset := &assets.Asset{
+							Name:        f.FileName,
+							DisplayName: fmt.Sprintf("%s (%s package)", f.FileName, v.PackageType),
+							URL:         assetURL,
+						}
+						candidates = append(candidates, asset)
+						log.Debugf("Adding %s with URL %s", asset, asset.URL)
+					}
+					candidateURLs[assetURL] = struct{}{}
+				}
 			}
 		}
 	}
@@ -115,7 +125,7 @@ func (g *gitLab) Fetch() (*File, error) {
 					URL:         link.URL,
 				}
 				candidates = append(candidates, asset)
-				log.Debugf("Adding %s with URL %s", asset.Name, asset.URL)
+				log.Debugf("Adding %s with URL %s", asset, asset.URL)
 			}
 			candidateURLs[link.URL] = struct{}{}
 		}
@@ -138,7 +148,7 @@ func (g *gitLab) Fetch() (*File, error) {
 						URL:         assetURL,
 					}
 					candidates = append(candidates, asset)
-					log.Debugf("Adding %s with URL %s", asset.Name, asset.URL)
+					log.Debugf("Adding %s with URL %s", asset, asset.URL)
 				}
 				candidateURLs[assetURL] = struct{}{}
 			}

--- a/pkg/providers/gitlab.go
+++ b/pkg/providers/gitlab.go
@@ -104,7 +104,7 @@ func (g *gitLab) Fetch() (*File, error) {
 		return nil, err
 	}
 	projectUploadsURL := fmt.Sprintf("%s/uploads/", project.WebURL)
-	projectIsPublic := g.token == "" || project.Visibility == gitlab.PublicVisibility
+	projectIsPublic := g.token == "" || project.Visibility == "" || project.Visibility == gitlab.PublicVisibility
 	log.Debugf("Project is public: %v", projectIsPublic)
 	for _, link := range release.Assets.Links {
 		if projectIsPublic || !strings.HasPrefix(link.URL, projectUploadsURL) {


### PR DESCRIPTION
Prefer GitLab Package if found for release version

This allows downloads from private repositories where goreleaser/goreleaser#2002 and goreleaser/goreleaser#2005 are used to upload generic packages for a release.

On private repositories, the uploaded project files made by goreleaser without additional generic uploads are not accessible through the API but only through a web browser session.