### PR TITLE
Modified config to utilize the os.UserHomeDir() vs user.Current().HomeDir

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,8 +28,8 @@ type Binary struct {
 }
 
 func CheckAndLoad() error {
-
-	configDir := filepath.Join(os.UserHomeDir(), ".bin")
+	home, err := os.UserHomeDir()
+	configDir := filepath.Join(home, ".bin")
 
 	if err := os.Mkdir(configDir, 0755); err != nil && !os.IsExist(err) {
 		return fmt.Errorf("Error creating config directory [%v]", err)
@@ -97,7 +97,8 @@ func RemoveBinaries(paths []string) error {
 }
 
 func write() error {
-	f, err := os.OpenFile(filepath.Join(os.UserHomeDir(), ".bin", "config.json"), os.O_RDWR|os.O_CREATE, 0666)
+	home, err := os.UserHomeDir()
+	f, err := os.OpenFile(filepath.Join(home, ".bin", "config.json"), os.O_RDWR|os.O_CREATE, 0666)
 	if err != nil {
 		return err
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/user"
 	"path/filepath"
 	"runtime"
 
@@ -29,9 +28,8 @@ type Binary struct {
 }
 
 func CheckAndLoad() error {
-	u, _ := user.Current()
 
-	configDir := filepath.Join(u.HomeDir, ".bin")
+	configDir := filepath.Join(os.UserHomeDir(), ".bin")
 
 	if err := os.Mkdir(configDir, 0755); err != nil && !os.IsExist(err) {
 		return fmt.Errorf("Error creating config directory [%v]", err)
@@ -99,8 +97,7 @@ func RemoveBinaries(paths []string) error {
 }
 
 func write() error {
-	u, _ := user.Current()
-	f, err := os.OpenFile(filepath.Join(u.HomeDir, ".bin", "config.json"), os.O_RDWR|os.O_CREATE, 0666)
+	f, err := os.OpenFile(filepath.Join(os.UserHomeDir(), ".bin", "config.json"), os.O_RDWR|os.O_CREATE, 0666)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Changed from user.Current().HomeDir to us the go function: os.UserHomeDir()

This change allows users to modify their home directory via environment variables (plan9 on Unix, and %USERPROFILE% on windows), vs mandating the OS-specified "current" user setting be used.  This allows a more "portable" use of your application.

For more info on this function see:
https://golang.org/src/os/file.go?s=14576:14610#L483