### PR TITLE
Add ensure command

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ bin install docker://quay.io/calico/node # install the latest version of calico/
 
 ```
 bin install <repo> [path] # Downloads the latest binary and makes it executable 
+bin ensure # Ensures that all binaries listed in the configuration are present
 bin update [bin]... # Scans binaries and prompts for update
 bin ls # List current binaries and it's versions
 bin remove <bin>... # Deletes one or more binaries

--- a/README.md
+++ b/README.md
@@ -1,27 +1,27 @@
 # bin
+
 Manages bin files downloaded from different sources
 
 ![bin](https://user-images.githubusercontent.com/1578458/87901619-ee629a80-ca2d-11ea-8609-8a8eb39801d2.gif)
 
-
 ## Rationale
 
-`bin` started as an idea given the popularity of single binary releases due to the surge of  languages like 
-Go, Rust, Deno, etc which can easily produce dynamically and statically compiled binarines. 
+`bin` started as an idea given the popularity of single binary releases due to the surge of  languages like
+Go, Rust, Deno, etc which can easily produce dynamically and statically compiled binarines.
 
 I found myself downloading binaries (or tarballs) directly from VCS (Github mostly) and then it was hard
-to keep control and update such dependencies whenever a new version was released. So, with the objective 
+to keep control and update such dependencies whenever a new version was released. So, with the objective
 to solve that problem and also looking for something that will allow me to get the latest releases, I created `bin`.
-In addition to that, I was also looking for something that doesn't require `sudo` or `root` privileges to install 
+In addition to that, I was also looking for something that doesn't require `sudo` or `root` privileges to install
 these binaries as downloading, making them executable and storing it somewhere in your PATH would be sufficient.
 
-After I finished the first MVP, a friend pointed out that [brew](https://brew.sh) was now supported in linux which almost 
+After I finished the first MVP, a friend pointed out that [brew](https://brew.sh) was now supported in linux which almost
 made me abandon the project. After checking out brew (never been an osx user), I found it a bit bloated and seems
 to be doing way more than what I'm actually needing. So, I've decided to continue `bin` and hopefully add more features
-that could result useful to someone else. 
+that could result useful to someone else.
 
-If you find `bin` helpful and you have any ideas or suggestions, please create an issue here or send a PR and I'll 
-be more than happy to brainstrom about possibilities. 
+If you find `bin` helpful and you have any ideas or suggestions, please create an issue here or send a PR and I'll
+be more than happy to brainstrom about possibilities.
 
 ## Installing
 
@@ -30,29 +30,28 @@ be more than happy to brainstrom about possibilities.
 3. Run `bin ls` to make sure bin has been installed correctly. You can now remove the first file you downloaded.
 4. Enjoy!
 
-
 ## Usage
 
 Install a release from github with the following command:
 
-```
+```shell
 bin install github.com/kubernetes-sigs/kind # installs latest Kind release
 
 bin install github.com/kubernetes-sigs/kind/releases/tag/v0.8.0 # installs a specific release
 
-bin install github.com/kubernetes-sigs/kind ~/bin/kind # installs latest on a specific path 
+bin install github.com/kubernetes-sigs/kind ~/bin/kind # installs latest on a specific path
 ```
 
 You can install Docker images and use them as regular CLIs:
 
-```
+```shell
 bin install docker://hashicorp/terraform:light # install the `light` tag for terraform
 
 bin install docker://quay.io/calico/node # install the latest version of calico/node
 ```
 
-```
-bin install <repo> [path] # Downloads the latest binary and makes it executable 
+```shell
+bin install <repo> [path] # Downloads the latest binary and makes it executable
 bin ensure # Ensures that all binaries listed in the configuration are present
 bin update [bin]... # Scans binaries and prompts for update
 bin ls # List current binaries and it's versions
@@ -62,8 +61,6 @@ bin purge # Removes from the DB missing binaries
 
 ## FAQ
 
-### There are some bugs and the code is not tested. 
+### There are some bugs and the code is not tested
 
-I know.. and that's not planning to change any time soon unless I start getting some contributions. I did this as a personal tool and I'll probably be fixing stuff and adding features as I personally need them. Contributions are welcome though and I'll be happy to discuss and review them. 
-
-
+I know.. and that's not planning to change any time soon unless I start getting some contributions. I did this as a personal tool and I'll probably be fixing stuff and adding features as I personally need them. Contributions are welcome though and I'll be happy to discuss and review them.

--- a/README.md
+++ b/README.md
@@ -51,12 +51,13 @@ bin install docker://quay.io/calico/node # install the latest version of calico/
 ```
 
 ```shell
-bin install <repo> [path] # Downloads the latest binary and makes it executable
 bin ensure # Ensures that all binaries listed in the configuration are present
-bin update [bin]... # Scans binaries and prompts for update
-bin ls # List current binaries and it's versions
+bin help # Help about any command
+bin install <repo> [path] # Downloads the latest binary and makes it executable
+bin list # List current binaries and it's versions
+bin prune # Removes from the DB missing binaries
 bin remove <bin>... # Deletes one or more binaries
-bin purge # Removes from the DB missing binaries
+bin update [bin]... # Scans binaries and prompts for update
 ```
 
 ## FAQ

--- a/cmd/ensure.go
+++ b/cmd/ensure.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/apex/log"
+	"github.com/fatih/color"
+	"github.com/marcosnils/bin/pkg/config"
+	"github.com/marcosnils/bin/pkg/providers"
+	"github.com/spf13/cobra"
+)
+
+type ensureCmd struct {
+	cmd *cobra.Command
+}
+
+func newEnsureCmd() *ensureCmd {
+	root := &ensureCmd{}
+	// nolint: dupl
+	cmd := &cobra.Command{
+		Use:           "ensure",
+		Aliases:       []string{"e"},
+		Short:         "Ensures that all binaries listed in the configuration are present",
+		SilenceUsage:  true,
+		Args:          cobra.MaximumNArgs(0),
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg := config.Get()
+			binsToProcess := cfg.Bins
+
+			// TODO: code smell here, this pretty much does
+			// the same thing as install logic. Refactor to
+			// use the same code in both places
+			for _, binCfg := range binsToProcess {
+				_, err := os.Stat(binCfg.Path)
+				if !os.IsNotExist(err) {
+					continue
+				}
+
+				p, err := providers.New(binCfg.URL, binCfg.Provider)
+				if err != nil {
+					return err
+				}
+
+				pResult, err := p.Fetch()
+				if err != nil {
+					return err
+				}
+
+				if err = saveToDisk(pResult, binCfg.Path, true); err != nil {
+					return fmt.Errorf("Error installing binary %w", err)
+				}
+
+				err = config.UpsertBinary(&config.Binary{
+					RemoteName: pResult.Name,
+					Path:       binCfg.Path,
+					Version:    pResult.Version,
+					Hash:       fmt.Sprintf("%x", pResult.Hash.Sum(nil)),
+					URL:        binCfg.URL,
+				})
+				if err != nil {
+					return err
+				}
+				log.Infof("Done ensuring %s to %s", binCfg.Path, color.GreenString(binCfg.Version))
+			}
+			return nil
+		},
+	}
+
+	root.cmd = cmd
+	return root
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,8 +20,8 @@ func Execute(version string, exit func(int), args []string) {
 
 	log.SetHandler(cli.Default)
 
-	//fmt.Println()
-	//defer fmt.Println()
+	// fmt.Println()
+	// defer fmt.Println()
 	newRootCmd(version, exit).Execute(args)
 }
 
@@ -33,8 +33,8 @@ func (cmd *rootCmd) Execute(args []string) {
 	}
 
 	if err := cmd.cmd.Execute(); err != nil {
-		var code = 1
-		var msg = "command failed"
+		code := 1
+		msg := "command failed"
 		if eerr, ok := err.(*exitError); ok {
 			code = eerr.code
 			if eerr.details != "" {
@@ -53,10 +53,10 @@ type rootCmd struct {
 }
 
 func newRootCmd(version string, exit func(int)) *rootCmd {
-	var root = &rootCmd{
+	root := &rootCmd{
 		exit: exit,
 	}
-	var cmd = &cobra.Command{
+	cmd := &cobra.Command{
 		Use:           "bin",
 		Short:         "Effortless binary manager",
 		Version:       version,
@@ -68,7 +68,7 @@ func newRootCmd(version string, exit func(int)) *rootCmd {
 				log.Debug("debug logs enabled")
 			}
 
-			//check and load config after handlers are configured
+			// check and load config after handlers are configured
 			err := config.CheckAndLoad()
 			if err != nil {
 				log.Fatalf("Error loading config file %v", err)
@@ -79,6 +79,7 @@ func newRootCmd(version string, exit func(int)) *rootCmd {
 	cmd.PersistentFlags().BoolVar(&root.debug, "debug", false, "Enable debug mode")
 	cmd.AddCommand(
 		newInstallCmd().cmd,
+		newEnsureCmd().cmd,
 		newUpdateCmd().cmd,
 		newRemoveCmd().cmd,
 		newListCmd().cmd,


### PR DESCRIPTION
Fixes: #57

This is really quick'n'dirty by more or less copy and adopt from the `update` command. But it does work in the sense, that it ensures the latest version of the binaries listed in the config file to be present.

The whole story about version pinning (install the version mentioned in the config file) is not solved. I guess this is addressed in #50.