### PR TITLE
Fall back to repo name if name consists only of replaced literals

### DIFF
--- a/pkg/assets/assets.go
+++ b/pkg/assets/assets.go
@@ -163,17 +163,20 @@ func SanitizeName(name, version string) string {
 			replacements = append(replacements, "_"+osName+archName, "")
 			replacements = append(replacements, "-"+osName+archName, "")
 			replacements = append(replacements, "."+osName+archName, "")
+			replacements = append(replacements, osName+archName, "")
 
 			if firstPass {
 				replacements = append(replacements, "_"+archName, "")
 				replacements = append(replacements, "-"+archName, "")
 				replacements = append(replacements, "."+archName, "")
+				replacements = append(replacements, archName, "")
 			}
 		}
 
 		replacements = append(replacements, "_"+osName, "")
 		replacements = append(replacements, "-"+osName, "")
 		replacements = append(replacements, "."+osName, "")
+		replacements = append(replacements, osName, "")
 
 		firstPass = false
 

--- a/pkg/assets/assets_test.go
+++ b/pkg/assets/assets_test.go
@@ -36,6 +36,7 @@ func TestSanitizeName(t *testing.T) {
 		{"launchpad-linux-x64", "1.2.0-rc.1", "launchpad", linuxAMDResolver},
 		{"launchpad-win-x64.exe", "1.2.0-rc.1", "launchpad.exe", windowsAMDResolver},
 		{"bin_0.0.1_Windows_x86_64.exe", "0.0.1", "bin.exe", windowsAMDResolver},
+		{"linux-amd64", "1.2.2", "", linuxAMDResolver},
 	}
 
 	for _, c := range cases {

--- a/pkg/providers/github.go
+++ b/pkg/providers/github.go
@@ -60,7 +60,11 @@ func (g *gitHub) Fetch() (*File, error) {
 	// TODO calculate file hash. Not sure if we can / should do it here
 	// since we don't want to read the file unnecesarily. Additionally, sometimes
 	// releases have .sha256 files, so it'd be nice to check for those also
-	f := &File{Data: outputFile, Name: assets.SanitizeName(name, version), Hash: sha256.New(), Version: version}
+	sanitizedName := assets.SanitizeName(name, version)
+	if sanitizedName == "" {
+		sanitizedName = g.repo
+	}
+	f := &File{Data: outputFile, Name: sanitizedName, Hash: sha256.New(), Version: version}
 
 	return f, nil
 }


### PR DESCRIPTION
Adds additional replacements to match a leading `linux` in the name. This may cause regressions.

Fixes #68.