### PR TITLE
Fix bin update on prerelease-only github repos

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -164,6 +164,9 @@ func getLatestVersion(b *config.Binary, p providers.Provider) (*updateInfo, erro
 	if err != nil {
 		return nil, fmt.Errorf("Error checking updates for %s, %w", b.Path, err)
 	}
+	if v == "" && u == "" {
+		return nil, nil
+	}
 
 	if b.Version == v {
 		return nil, nil

--- a/pkg/providers/github.go
+++ b/pkg/providers/github.go
@@ -29,16 +29,12 @@ func (g *gitHub) Fetch(opts *FetchOpts) (*File, error) {
 
 	// If we have a tag, let's fetch from there
 	var err error
-	var resp *github.Response
 	if len(g.tag) > 0 {
 		log.Infof("Getting %s release for %s/%s", g.tag, g.owner, g.repo)
 		release, _, err = g.client.Repositories.GetReleaseByTag(context.TODO(), g.owner, g.repo, g.tag)
 	} else {
 		log.Infof("Getting latest release for %s/%s", g.owner, g.repo)
-		release, resp, err = g.client.Repositories.GetLatestRelease(context.TODO(), g.owner, g.repo)
-		if resp.StatusCode == http.StatusNotFound {
-			err = fmt.Errorf("repository %s/%s does not have releases", g.owner, g.repo)
-		}
+		release, err = g.getAnyLatestRelease(context.TODO())
 	}
 
 	if err != nil {
@@ -80,26 +76,33 @@ func (g *gitHub) Fetch(opts *FetchOpts) (*File, error) {
 // returns the corresponding name and url to fetch the version
 func (g *gitHub) GetLatestVersion() (string, string, error) {
 	log.Debugf("Getting latest release for %s/%s", g.owner, g.repo)
-	release, _, err := g.client.Repositories.GetLatestRelease(context.TODO(), g.owner, g.repo)
+	release, err := g.getAnyLatestRelease(context.TODO())
 	if err != nil {
-		// If the error is that no latest release was found, it could be that there are only pre-releases
-		if ghErrResp, ok := err.(*github.ErrorResponse); ok && ghErrResp.Response.StatusCode == http.StatusNotFound {
-			// Get the first release returned by ListReleases
-			releases, _, listErr := g.client.Repositories.ListReleases(context.TODO(), g.owner, g.repo, &github.ListOptions{PerPage: 1})
-			if listErr != nil {
-				return "", "", listErr
-			}
-			if len(releases) > 0 {
-				return releases[0].GetTagName(), releases[0].GetHTMLURL(), nil
-			}
-			// Return original 404/StatusNotFound error from GetLatestRelease
-			return "", "", err
-		}
-
 		return "", "", err
 	}
 
 	return release.GetTagName(), release.GetHTMLURL(), nil
+}
+
+func (g *gitHub) getAnyLatestRelease(ctx context.Context) (*github.RepositoryRelease, error) {
+	release, _, err := g.client.Repositories.GetLatestRelease(ctx, g.owner, g.repo)
+	if err != nil {
+		// If the error is that no latest release was found, it could be that there are only pre-releases
+		if ghErrResp, ok := err.(*github.ErrorResponse); ok && ghErrResp.Response.StatusCode == http.StatusNotFound {
+			// Get the first release returned by ListReleases
+			releases, _, listErr := g.client.Repositories.ListReleases(ctx, g.owner, g.repo, &github.ListOptions{PerPage: 1})
+			if listErr != nil {
+				return nil, listErr
+			}
+			if len(releases) > 0 {
+				return releases[0], nil
+			}
+		}
+
+		// Return original 404/StatusNotFound error from GetLatestRelease
+		return nil, err
+	}
+	return release, err
 }
 
 func (g *gitHub) GetID() string {


### PR DESCRIPTION
Relates to #86.
Fixes #84.

A future PR could add a (per-binary?) option to offer the latest prerelease if newer than latest release.