### PR TITLE
WIP: Feature/add config cmd

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,0 +1,98 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/apex/log"
+	"github.com/marcosnils/bin/pkg/config"
+	"github.com/spf13/cobra"
+)
+
+type cfgCmd struct {
+	cmd *cobra.Command
+}
+
+type cfgGetCmd struct {
+	cmd *cobra.Command
+}
+
+type cfgSetCmd struct {
+	cmd *cobra.Command
+}
+
+func newConfigCmd() *cfgCmd {
+	cfg := &cfgCmd{}
+	// nolint: dupl
+	cmd := &cobra.Command{
+		Use:           "config",
+		Aliases:       []string{"c"},
+		Short:         "Configure bin",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Run: func(cmd *cobra.Command, args []string) {
+			log.Debug("Run config")
+		},
+	}
+
+	cmd.AddCommand(
+		newConfigGetCmd().cmd,
+		newConfigSetCmd().cmd,
+	)
+
+	cfg.cmd = cmd
+	return cfg
+}
+
+func newConfigGetCmd() *cfgGetCmd {
+	get := &cfgGetCmd{}
+	cmd := &cobra.Command{
+		Use:     "get <name>",
+		Aliases: []string{"g"},
+		Short:   "Get a configuration value",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return fmt.Errorf("expexting exactly one argument (got %d)", len(args))
+			}
+			return nil
+		},
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			log.Debug("Run config get")
+
+			v, err := config.GetValue(args[0])
+			if err != nil {
+				return err
+			}
+			fmt.Printf("%s", v)
+			return nil
+		},
+	}
+
+	get.cmd = cmd
+	return get
+}
+
+func newConfigSetCmd() *cfgSetCmd {
+	set := &cfgSetCmd{}
+	cmd := &cobra.Command{
+		Use:     "set <name> <value>",
+		Aliases: []string{"s"},
+		Short:   "Set a configuration value",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 2 {
+				return fmt.Errorf("expecting exactly two arguments (got %d)", len(args))
+			}
+			return nil
+		},
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			log.Debug("Run config set")
+
+			return config.SetValue(args[0], args[1])
+		},
+	}
+
+	set.cmd = cmd
+	return set
+}

--- a/cmd/ensure.go
+++ b/cmd/ensure.go
@@ -26,8 +26,7 @@ func newEnsureCmd() *ensureCmd {
 		Args:          cobra.MaximumNArgs(0),
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg := config.Get()
-			binsToProcess := cfg.Bins
+			_, binsToProcess := config.Get()
 
 			// TODO: code smell here, this pretty much does
 			// the same thing as install logic. Refactor to

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -44,6 +44,7 @@ func newInstallCmd() *installCmd {
 			//have to calculate it each time. Afterwards, bin users can change this
 			//path by editing bin's config file or maybe introdice the `bin config` command
 
+			cfg, _ := config.Get()
 			var path string
 			if len(args) > 1 {
 				var err error
@@ -51,8 +52,8 @@ func newInstallCmd() *installCmd {
 				if path, err = filepath.Abs(args[1]); err != nil {
 					return err
 				}
-			} else if len(config.Get().DefaultPath) > 0 {
-				path = config.Get().DefaultPath
+			} else if len(cfg.DefaultPath) > 0 {
+				path = cfg.DefaultPath
 			} else {
 				var err error
 				path, err = os.Getwd()

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -30,16 +30,16 @@ func newListCmd() *listCmd {
 
 			defer w.Flush()
 
-			cfg := config.Get()
+			_, bins := config.Get()
 
 			fmt.Fprintf(w, "\n %s\t%s\t%s\t%s", "Path", "Version", "URL", "Status")
 			binPaths := []string{}
-			for k := range cfg.Bins {
+			for k := range bins {
 				binPaths = append(binPaths, k)
 			}
 			sort.Strings(binPaths)
 			for _, k := range binPaths {
-				b := cfg.Bins[k]
+				b := bins[k]
 
 				_, err := os.Stat(b.Path)
 

--- a/cmd/prune.go
+++ b/cmd/prune.go
@@ -22,10 +22,10 @@ func newPruneCmd() *pruneCmd {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg := config.Get()
+			_, bins := config.Get()
 
 			pathsToDel := []string{}
-			for _, b := range cfg.Bins {
+			for _, b := range bins {
 				if _, err := os.Stat(b.Path); os.IsNotExist(err) {
 					log.Infof("%s not found removing", b.Path)
 					pathsToDel = append(pathsToDel, b.Path)

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -24,17 +24,16 @@ func newRemoveCmd() *removeCmd {
 		Args:          cobra.MinimumNArgs(1),
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg := config.Get()
+			_, bins := config.Get()
 
 			existingToRemove := []string{}
-
 			for _, p := range args {
 				p, err := getBinPath(p)
 				if err != nil {
 					return err
 				}
 
-				if _, ok := cfg.Bins[p]; ok {
+				if _, ok := bins[p]; ok {
 					existingToRemove = append(existingToRemove, p)
 					// TODO some providers (like docker) might download
 					// additional things somewhere else, maybe we should

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -123,9 +123,9 @@ func getBinPath(name string) (string, error) {
 		return name, nil
 	}
 
-	cfg := config.Get()
+	_, bins := config.Get()
 
-	for _, bin := range cfg.Bins {
+	for _, bin := range bins {
 		if bin.RemoteName == name {
 			return bin.Path, nil
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -68,8 +68,9 @@ func newRootCmd(version string, exit func(int)) *rootCmd {
 				log.Debug("debug logs enabled")
 			}
 
-			// check and load config after handlers are configured
-			err := config.CheckAndLoad()
+			// check and load config after handlers are configured, ignore if the
+			// base path is set, if the command is the `config` command
+			err := config.CheckAndLoad( cmd.Parent().Name() != "config")
 			if err != nil {
 				log.Fatalf("Error loading config file %v", err)
 			}
@@ -84,6 +85,7 @@ func newRootCmd(version string, exit func(int)) *rootCmd {
 		newRemoveCmd().cmd,
 		newListCmd().cmd,
 		newPruneCmd().cmd,
+		newConfigCmd().cmd,
 	)
 
 	root.cmd = cmd

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -47,8 +47,8 @@ func newUpdateCmd() *updateCmd {
 			// interface to support this use-case
 
 			toUpdate := map[*updateInfo]*config.Binary{}
-			cfg := config.Get()
-			binsToProcess := cfg.Bins
+			_, bins := config.Get()
+			binsToProcess := bins
 
 			// Update single binary
 			if bin != "" {
@@ -56,7 +56,7 @@ func newUpdateCmd() *updateCmd {
 				if err != nil {
 					return err
 				}
-				binsToProcess = map[string]*config.Binary{bin: cfg.Bins[bin]}
+				binsToProcess = map[string]*config.Binary{bin: bins[bin]}
 			}
 			for _, b := range binsToProcess {
 				p, err := providers.New(b.URL, b.Provider)

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/testify v1.6.1 // indirect
+	github.com/tidwall/gjson v1.7.3 // indirect
 	github.com/xanzy/go-gitlab v0.44.0
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8
 	github.com/yuin/goldmark v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -188,6 +188,12 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/tidwall/gjson v1.7.3 h1:9dOulDrkCJf1mwljVMhXNQr9ZL2NvajRX7A1R8c6Qxw=
+github.com/tidwall/gjson v1.7.3/go.mod h1:5/xDoumyyDNerp2U36lyolv46b3uF/9Bu6OfyQ9GImk=
+github.com/tidwall/match v1.0.3 h1:FQUVvBImDutD8wJLN6c5eMzWtjgONK9MwIBCOrUJKeE=
+github.com/tidwall/match v1.0.3/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.1.0 h1:K3hMW5epkdAVwibsQEfR/7Zj0Qgt4DxtNumTq/VloO8=
+github.com/tidwall/pretty v1.1.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tj/assert v0.0.0-20171129193455-018094318fb0/go.mod h1:mZ9/Rh9oLWpLLDRpvE+3b7gP/C2YyLFYxNmcLnPTMe0=
 github.com/tj/go-elastic v0.0.0-20171221160941-36157cbbebc2/go.mod h1:WjeM0Oo1eNAjXGDx2yma7uG2XoyRZTq1uv3M/o7imD0=
 github.com/tj/go-kinesis v0.0.0-20171128231115-08b17f58cb1b/go.mod h1:/yhzCV0xPfx6jb1bBgRFjl5lytqVqZXEaeqWP8lTEao=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -167,6 +167,8 @@ func GetValue(key string) (interface{}, error) {
 	return nil, fmt.Errorf("configuration field not found: %s", key)
 }
 
+// ToDo: compare the type of the field with the value and
+//       set only if they match/are compatible
 func SetValue(key string, value interface{}) error {
   val := reflect.ValueOf(&cfg).Elem()
   for i := 0; i < val.NumField(); i++ {
@@ -174,9 +176,10 @@ func SetValue(key string, value interface{}) error {
     tag := field.Tag.Get("json")
     if field.Name == key || tag == key {
       val.Field(i).SetString(value.(string))
+      return writeConfig()
     }
   }
-  return writeConfig()
+  return fmt.Errorf("configuration field not found: %s", key)
 }
 
 // UpsertBinary adds or updats an existing


### PR DESCRIPTION
This PR is a concept for introducing a `config` command. I think it would be a nice feature to modify the configuration via a dedicated command. For example to set up the default path without interacting with the command line (scripted).
In my case, for example,  I would use that to set up `bin` as part of my dotfiles-setup:
```shell
> bin config set default_path /home/user/.local/bin
> bin install ….
```

In this concept, the config-struct is accessed via reflection to make it easy to add/remove config fields later without maintaining a list of available fields.

During the implementation, I came to the conclusion, that it would be way easier (nicer) if the configuration file and the bin-database would be in separate files. Also in view of the fact that the configuration could become more extensive overtime. 
Otherwise, the database would have to be considered separately in any case, because in my opinion, it would not make sense, for example, to change the hash value of an entry.
So I separated the files and implemented a check, whether there is already a configuration, and convert it if that’s the case.

Implemented so far:

- `bin config set <name> <value>`
- `bin config get <name>`