### PR TITLE
Remove unused func param

### DIFF
--- a/pkg/providers/docker.go
+++ b/pkg/providers/docker.go
@@ -57,10 +57,7 @@ func (d *docker) GetID() string {
 func newDocker(imageURL string) (Provider, error) {
 	imageURL = strings.TrimPrefix(imageURL, "docker://")
 
-	repo, tag, err := parseImage(imageURL)
-	if err != nil {
-		return nil, err
-	}
+	repo, tag := parseImage(imageURL)
 
 	client, err := client.NewClientWithOpts()
 	if err != nil {
@@ -73,7 +70,7 @@ func newDocker(imageURL string) (Provider, error) {
 // parseImage parses the image returning the repository, tag
 // and an error if it fails. ParseImage handles non-canonical
 // URLs like `hashicorp/terraform`.
-func parseImage(imageURL string) (string, string, error) {
+func parseImage(imageURL string) (string, string) {
 	image := imageURL
 	tag := "latest"
 	if i := strings.LastIndex(imageURL, ":"); i > -1 {
@@ -85,5 +82,5 @@ func parseImage(imageURL string) (string, string, error) {
 		image = "library/" + image
 	}
 
-	return image, tag, nil
+	return image, tag
 }

--- a/pkg/providers/docker.go
+++ b/pkg/providers/docker.go
@@ -67,9 +67,8 @@ func newDocker(imageURL string) (Provider, error) {
 	return &docker{repo: repo, tag: tag, client: client}, nil
 }
 
-// parseImage parses the image returning the repository, tag
-// and an error if it fails. ParseImage handles non-canonical
-// URLs like `hashicorp/terraform`.
+// parseImage parses the image returning the repository and tag.
+// It handles non-canonical URLs like `hashicorp/terraform`.
 func parseImage(imageURL string) (string, string) {
 	image := imageURL
 	tag := "latest"

--- a/pkg/providers/docker_test.go
+++ b/pkg/providers/docker_test.go
@@ -20,14 +20,12 @@ func TestParseImage(t *testing.T) {
 
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
-			repo, tag, err := parseImage(test.imageURL)
+			repo, tag := parseImage(test.imageURL)
 			switch {
 			case test.expectedRepo != repo:
 				t.Errorf("expected repo was %s, got %s", test.expectedRepo, repo)
 			case test.expectedTag != tag:
 				t.Errorf("expected tag was %s, got %s", test.expectedTag, tag)
-			case test.withErr != (err != nil):
-				t.Errorf("expected err != nil to be %v", test.withErr)
 			}
 		})
 	}


### PR DESCRIPTION
Found this one with [unparam](https://github.com/mvdan/unparam)

This PR just remove the unused function parameter and references to it.
