### PR TITLE
This commit adds --all flag to install and update to skip

### DIFF
--- a/cmd/ensure.go
+++ b/cmd/ensure.go
@@ -43,7 +43,7 @@ func newEnsureCmd() *ensureCmd {
 					return err
 				}
 
-				pResult, err := p.Fetch()
+				pResult, err := p.Fetch(&providers.FetchOpts{})
 				if err != nil {
 					return err
 				}

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -20,6 +20,7 @@ type installCmd struct {
 type installOpts struct {
 	force    bool
 	provider string
+	all      bool
 }
 
 func newInstallCmd() *installCmd {
@@ -33,16 +34,7 @@ func newInstallCmd() *installCmd {
 		SilenceErrors: true,
 		Args:          cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			//TODO implement --force(-f) flag for install
-			// to override the binary if exists
 			u := args[0]
-
-			//TODO make this path optional. If the path
-			//is not specified bin could automatically
-			//select a PATH that could write and install the binaries there.
-			//Additionally, it could store that path in the config file so it doesn't
-			//have to calculate it each time. Afterwards, bin users can change this
-			//path by editing bin's config file or maybe introdice the `bin config` command
 
 			var path string
 			if len(args) > 1 {
@@ -69,7 +61,7 @@ func newInstallCmd() *installCmd {
 				return err
 			}
 
-			pResult, err := p.Fetch()
+			pResult, err := p.Fetch(&providers.FetchOpts{All: root.opts.all})
 
 			if err != nil {
 				return err
@@ -106,6 +98,7 @@ func newInstallCmd() *installCmd {
 
 	root.cmd = cmd
 	root.cmd.Flags().BoolVarP(&root.opts.force, "force", "f", false, "Force the installation even if the file already exists")
+	root.cmd.Flags().BoolVarP(&root.opts.all, "all", "a", false, "Show all possible download options (skip scoring & filtering)")
 	root.cmd.Flags().StringVarP(&root.opts.provider, "provider", "p", "", "Forces to use a specific provider")
 	return root
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -21,6 +21,7 @@ type updateCmd struct {
 
 type updateOpts struct {
 	dryRun bool
+	all    bool
 }
 
 type updateInfo struct{ version, url string }
@@ -111,7 +112,7 @@ func newUpdateCmd() *updateCmd {
 					return err
 				}
 
-				pResult, err := p.Fetch()
+				pResult, err := p.Fetch(&providers.FetchOpts{All: root.opts.all})
 				if err != nil {
 					return err
 				}
@@ -139,6 +140,7 @@ func newUpdateCmd() *updateCmd {
 
 	root.cmd = cmd
 	root.cmd.Flags().BoolVarP(&root.opts.dryRun, "dry-run", "", false, "Only show status, don't prompt for update")
+	root.cmd.Flags().BoolVarP(&root.opts.all, "all", "a", false, "Show all possible download options (skip scoring & filtering)")
 	return root
 }
 

--- a/pkg/assets/assets_test.go
+++ b/pkg/assets/assets_test.go
@@ -149,9 +149,10 @@ func TestFilterAssets(t *testing.T) {
 		}}, "dapr", testLinuxAMDResolver},
 	}
 
+	f := NewFilter(&FilterOpts{})
 	for _, c := range cases {
 		resolver = c.resolver
-		if n, err := FilterAssets(c.in.repoName, c.in.as); err != nil {
+		if n, err := f.FilterAssets(c.in.repoName, c.in.as); err != nil {
 			t.Fatalf("Error filtering assets %v", err)
 		} else if n.Name != c.out {
 			t.Fatalf("Error filtering %+v: %+v does not match %s", c.in, n, c.out)

--- a/pkg/providers/docker.go
+++ b/pkg/providers/docker.go
@@ -18,7 +18,7 @@ type docker struct {
 	repo, tag string
 }
 
-func (d *docker) Fetch() (*File, error) {
+func (d *docker) Fetch(opts *FetchOpts) (*File, error) {
 	log.Infof("Pulling docker image %s:%s", d.repo, d.tag)
 	out, err := d.client.ImageCreate(context.Background(), fmt.Sprintf("%s:%s", d.repo, d.tag), types.ImageCreateOptions{})
 	if err != nil {

--- a/pkg/providers/hashicorp.go
+++ b/pkg/providers/hashicorp.go
@@ -71,7 +71,7 @@ func (g *hashiCorp) GetID() string {
 	return "hashicorp"
 }
 
-func (g *hashiCorp) Fetch() (*File, error) {
+func (g *hashiCorp) Fetch(opts *FetchOpts) (*File, error) {
 	var release *hashiCorpRelease
 
 	// If we have a tag, let's fetch from there
@@ -97,12 +97,13 @@ func (g *hashiCorp) Fetch() (*File, error) {
 		candidates = append(candidates, &assets.Asset{Name: link.Filename, URL: link.URL})
 	}
 
-	gf, err := assets.FilterAssets(g.repo, candidates)
+	f := assets.NewFilter(&assets.FilterOpts{SkipScoring: opts.All})
+	gf, err := f.FilterAssets(g.repo, candidates)
 	if err != nil {
 		return nil, err
 	}
 
-	name, outputFile, err := assets.ProcessURL(gf)
+	name, outputFile, err := f.ProcessURL(gf)
 	if err != nil {
 		return nil, err
 	}
@@ -112,9 +113,9 @@ func (g *hashiCorp) Fetch() (*File, error) {
 	// TODO calculate file hash. Not sure if we can / should do it here
 	// since we don't want to read the file unnecesarily. Additionally, sometimes
 	// releases have .sha256 files, so it'd be nice to check for those also
-	f := &File{Data: outputFile, Name: assets.SanitizeName(name, version), Hash: sha256.New(), Version: version}
+	file := &File{Data: outputFile, Name: assets.SanitizeName(name, version), Hash: sha256.New(), Version: version}
 
-	return f, nil
+	return file, nil
 }
 
 // GetLatestVersion checks the latest repo release and

--- a/pkg/providers/providers.go
+++ b/pkg/providers/providers.go
@@ -20,10 +20,14 @@ type File struct {
 	Length  int64
 }
 
+type FetchOpts struct {
+	All bool
+}
+
 type Provider interface {
 	// Fetch returns the file metadata to retrieve a specific binary given
 	// for a provider
-	Fetch() (*File, error)
+	Fetch(*FetchOpts) (*File, error)
 	// GetLatestVersion returns the version and the URL of the
 	// latest version for this binary
 	GetLatestVersion() (string, string, error)


### PR DESCRIPTION
scoring process and return all assets fetched by a provider
regardless of the architecture and OS.

I haven't added any tests since if the logic is worng, current
tests fail due to scoring logic returning invalid results

Fixes #96