### PR TITLE
Improve XP when using --all flag.

### DIFF
--- a/pkg/assets/assets_test.go
+++ b/pkg/assets/assets_test.go
@@ -149,10 +149,13 @@ func TestFilterAssets(t *testing.T) {
 		}}, "dapr", testLinuxAMDResolver},
 	}
 
-	f := NewFilter(&FilterOpts{})
+	f := NewFilter(&FilterOpts{SkipScoring: false})
 	for _, c := range cases {
 		resolver = c.resolver
 		if n, err := f.FilterAssets(c.in.repoName, c.in.as); err != nil {
+			for _, a := range c.in.as {
+				fmt.Println(a.Name, c.resolver)
+			}
 			t.Fatalf("Error filtering assets %v", err)
 		} else if n.Name != c.out {
 			t.Fatalf("Error filtering %+v: %+v does not match %s", c.in, n, c.out)

--- a/pkg/providers/gitlab.go
+++ b/pkg/providers/gitlab.go
@@ -204,10 +204,7 @@ func (g *gitLab) GetLatestVersion() (string, string, error) {
 	svToTagName := map[string]string{}
 	tagNameToRelease := map[string]*gitlab.Release{}
 	for _, release := range releases {
-		tagName := release.TagName
-		if strings.HasPrefix(tagName, "v") {
-			tagName = strings.TrimPrefix(tagName, "v")
-		}
+		tagName := strings.TrimPrefix(release.TagName, "v")
 		sv, err := semver.NewVersion(tagName)
 		if err != nil {
 			continue


### PR DESCRIPTION
This commit improves handling on the following cases:

- It filters directories from Zip extraction
- It handlers better the --all flag by showing exactly all the files
without any kind of filtering. Previously, even though that flag was
added, we were still doing some filtering based on the repo name

Fixes #103