### PR TITLE
Fix wrapper generated by docker_unix provider

### DIFF
--- a/pkg/providers/docker_unix.go
+++ b/pkg/providers/docker_unix.go
@@ -9,7 +9,7 @@ const (
 	// TODO: there might be a way were users can configure a template for the
 	// actual execution since some CLIs require some other folders to be mounted
 	// or networks to be shared
-	sh = `
+	sh = `#!/bin/sh
 	termflag=$([ -t 0 ] && echo -n "-t")
 	docker run --rm -i $termflag -v ${PWD}:/tmp/cmd -w /tmp/cmd %s:%s "$@"`
 )


### PR DESCRIPTION
Wrapper script generated by docker_unix provider does not contain shebang for the shell. Some shells may fail to execute the script. For example fish is affected.

Add shebang for /bin/sh to make the wrapper script more portable.