### PR TITLE
Allows to set manual download dir if can't be automatically detected

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -3,14 +3,15 @@ package cmd
 import (
 	"bufio"
 	"fmt"
+	"os"
+	"strings"
+
 	"github.com/apex/log"
 	"github.com/fatih/color"
 	"github.com/hashicorp/go-version"
 	"github.com/marcosnils/bin/pkg/config"
 	"github.com/marcosnils/bin/pkg/providers"
 	"github.com/spf13/cobra"
-	"os"
-	"strings"
 )
 
 type updateCmd struct {


### PR DESCRIPTION
This commits allows the user to specify a download directorty maunally
if it can't be automatically detected by traversing the PATH folders

Ideally it fixes 107

cc @walidshaari