### PR TITLE
Fix init on failure to find PATH automatically

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -69,15 +69,16 @@ func CheckAndLoad() error {
 				if err != nil {
 					return fmt.Errorf("Invalid input")
 				}
+				response = strings.TrimSpace(response)
 
-				if err = checkDirExistsAndWritable(strings.TrimSpace(response)); err != nil {
+				if err = checkDirExistsAndWritable(response); err != nil {
 					log.Debugf("Could not set download directory [%s]: [%v]", response, err)
 					// Keep looping until writable and existing dir is selected
 					continue
 				}
 
 				cfg.DefaultPath = response
-
+				break
 			}
 		}
 


### PR DESCRIPTION
Downloaded bin on a new machine and encountered the following behavior, with debug:

```console
$ bin --debug
   • debug logs enabled
   • Config directory is: /home/ubuntu/.config/bin
   • User PATH is [/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin]
   • Checking path /usr/local/sbin
   • Error [permission denied] checking path
   • Checking path /usr/local/bin
   • Error [permission denied] checking path
   • Checking path /usr/sbin
   • Error [permission denied] checking path
   • Checking path /usr/bin
   • Error [permission denied] checking path
   • Checking path /sbin
   • Error [permission denied] checking path
   • Checking path /bin
   • Error [permission denied] checking path
   • Checking path /usr/games
   • Error [permission denied] checking path
   • Checking path /usr/local/games
   • Error [permission denied] checking path
   • Checking path /snap/bin
   • Error [permission denied] checking path
   • Could not find a PATH directory automatically, falling back to manual selection

Please specify a download directory: /home/ubuntu/.bin
   • Could not find a PATH directory automatically, falling back to manual selection

Please specify a download directory: /home/ubuntu/Downloads
   • Could not set download directory [/home/ubuntu/Downloads
]: [Error setting download path [stat /home/ubuntu/Downloads: no such file or directory]]
   • Could not find a PATH directory automatically, falling back to manual selection

Please specify a download directory: /home/ubuntu/go
   • Could not find a PATH directory automatically, falling back to manual selection
```

It enters a loop and never comes out of it.
This change adds a break statement to help break out of the loop.

```console
$ bin
Please specify a download directory: /home/ubuntu/.bin
   • Download path set to /home/ubuntu/.bin


 Path   Version         URL     Status
```

After fixing the above, encountered an issue when trying to install a binary:

```console
$ bin install github.com/fluxcd/flux2
   • Getting latest release for fluxcd/flux2
   • Starting download of https://github.com/fluxcd/flux2/releases/download/v0.23.0/flux_0.23.0_linux_arm64.tar.gz
11.45 MiB / 11.45 MiB [---------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 3.86 MiB p/s 3s

   ⨯ command failed            error=Error installing binary: open /home/ubuntu/.bin
: file exists
```

Checked the bin config to find a white space in the `default_path`:

```console
$ cat ~/.config/bin/config.json
{
    "default_path": "/home/ubuntu/.bin\n",
    "bins": {}
}
```

Removing the newline from `default_path` made the binary installation above to succeed and list the installed binary:

```console
$ bin

 Path                           Version         URL                             Status
 /home/ubuntu/.bin/flux         v0.23.0         github.com/fluxcd/flux2         OK
```

Updated the loop that takes the input PATH to trim whitespace before using it and that fixed
all the problems.