### PR TITLE
Treat empty input as default suggested by prompt

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -98,7 +98,7 @@ func newUpdateCmd() *updateCmd {
 				}
 
 				switch strings.ToLower(strings.TrimSpace(response)) {
-				case "y", "yes":
+				case "", "y", "yes":
 				default:
 					return fmt.Errorf("Command aborted")
 				}


### PR DESCRIPTION
The prompt,`Do you want to continue? [Y/n]`, uses conventional notation where capitalized letter is default option.
Empty input line results in `Command aborted` which is unexpected behavior to user.
This change treats empty string the same as `"y"`