### PR TITLE
Fix XZed binaries similar to bzip2ed binaries

### DIFF
--- a/pkg/assets/assets.go
+++ b/pkg/assets/assets.go
@@ -364,7 +364,7 @@ func (f *Filter) processXz(name string, r io.Reader) (string, io.Reader, error) 
 		return "", nil, err
 	}
 
-	return "", xr, nil
+	return name, xr, nil
 }
 
 func (f *Filter) processZip(name string, r io.Reader) (string, io.Reader, error) {


### PR DESCRIPTION
Fix XZed binaries similar to bzip2ed binaries.

Similar to #117