### PR TITLE
Add support to persist package paths

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -78,12 +78,13 @@ func newInstallCmd() *installCmd {
 			}
 
 			err = config.UpsertBinary(&config.Binary{
-				RemoteName: pResult.Name,
-				Path:       path,
-				Version:    pResult.Version,
-				Hash:       fmt.Sprintf("%x", pResult.Hash.Sum(nil)),
-				URL:        u,
-				Provider:   p.GetID(),
+				RemoteName:  pResult.Name,
+				Path:        path,
+				Version:     pResult.Version,
+				Hash:        fmt.Sprintf("%x", pResult.Hash.Sum(nil)),
+				URL:         u,
+				Provider:    p.GetID(),
+				PackagePath: pResult.PackagePath,
 			})
 
 			if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,6 +28,10 @@ type Binary struct {
 	Hash       string `json:"hash"`
 	URL        string `json:"url"`
 	Provider   string `json:"provider"`
+	// if file is installed from a package format (zip, tar, etc) store
+	// the package path in config so we don't ask the user to select
+	// the path again when upgrading
+	PackagePath string `json:"package_path"`
 }
 
 func CheckAndLoad() error {

--- a/pkg/providers/gitlab.go
+++ b/pkg/providers/gitlab.go
@@ -151,7 +151,7 @@ func (g *gitLab) Fetch(opts *FetchOpts) (*File, error) {
 		return nil, err
 	}
 
-	f := assets.NewFilter(&assets.FilterOpts{SkipScoring: opts.All})
+	f := assets.NewFilter(&assets.FilterOpts{SkipScoring: opts.All, PackagePath: opts.PackagePath, SkipPathCheck: opts.SkipPatchCheck})
 
 	gf, err := f.FilterAssets(g.repo, candidates)
 	if err != nil {
@@ -165,7 +165,7 @@ func (g *gitLab) Fetch(opts *FetchOpts) (*File, error) {
 		gf.ExtraHeaders["PRIVATE-TOKEN"] = g.token
 	}
 
-	name, outputFile, err := f.ProcessURL(gf)
+	outFile, err := f.ProcessURL(gf)
 	if err != nil {
 		return nil, err
 	}
@@ -175,7 +175,7 @@ func (g *gitLab) Fetch(opts *FetchOpts) (*File, error) {
 	// TODO calculate file hash. Not sure if we can / should do it here
 	// since we don't want to read the file unnecesarily. Additionally, sometimes
 	// releases have .sha256 files, so it'd be nice to check for those also
-	file := &File{Data: outputFile, Name: assets.SanitizeName(name, version), Hash: sha256.New(), Version: version}
+	file := &File{Data: outFile.Source, Name: assets.SanitizeName(outFile.Name, version), Hash: sha256.New(), Version: version}
 
 	return file, nil
 }

--- a/pkg/providers/hashicorp.go
+++ b/pkg/providers/hashicorp.go
@@ -97,13 +97,13 @@ func (g *hashiCorp) Fetch(opts *FetchOpts) (*File, error) {
 		candidates = append(candidates, &assets.Asset{Name: link.Filename, URL: link.URL})
 	}
 
-	f := assets.NewFilter(&assets.FilterOpts{SkipScoring: opts.All})
+	f := assets.NewFilter(&assets.FilterOpts{SkipScoring: opts.All, PackagePath: opts.PackagePath, SkipPathCheck: opts.SkipPatchCheck})
 	gf, err := f.FilterAssets(g.repo, candidates)
 	if err != nil {
 		return nil, err
 	}
 
-	name, outputFile, err := f.ProcessURL(gf)
+	outFile, err := f.ProcessURL(gf)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +113,7 @@ func (g *hashiCorp) Fetch(opts *FetchOpts) (*File, error) {
 	// TODO calculate file hash. Not sure if we can / should do it here
 	// since we don't want to read the file unnecesarily. Additionally, sometimes
 	// releases have .sha256 files, so it'd be nice to check for those also
-	file := &File{Data: outputFile, Name: assets.SanitizeName(name, version), Hash: sha256.New(), Version: version}
+	file := &File{Data: outFile.Source, Name: assets.SanitizeName(outFile.Name, version), Hash: sha256.New(), Version: version}
 
 	return file, nil
 }

--- a/pkg/providers/providers.go
+++ b/pkg/providers/providers.go
@@ -13,15 +13,18 @@ import (
 var ErrInvalidProvider = errors.New("invalid provider")
 
 type File struct {
-	Data    io.Reader
-	Name    string
-	Hash    hash.Hash
-	Version string
-	Length  int64
+	Data        io.Reader
+	Name        string
+	Hash        hash.Hash
+	Version     string
+	Length      int64
+	PackagePath string
 }
 
 type FetchOpts struct {
-	All bool
+	All            bool
+	PackagePath    string
+	SkipPatchCheck bool
 }
 
 type Provider interface {


### PR DESCRIPTION
This commit adds support to persisting packages paths in the bin config
file so that when performing updates, user is not promoted to select the
path again.

Some projects like https://github.com/cli/cli/ add the release version in the archive file which makes this feature useless since it won't bring up any results. For those use-cases, I've added the `-p` flag which skips this path check during updates. 

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
