### PR TITLE
fix crash for invokation without args

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -100,9 +100,10 @@ func defaultCommand(cmd *cobra.Command, args []string) bool {
 
 	// special case for cobra's default completion command
 	// ref: https://github.com/kubernetes/kubectl/blob/04af20f5a9d2b56d910a36fec84f21164df65d32/pkg/cmd/cmd.go#L132
-	if arg0 := args[0]; arg0 == "completion" ||
-		arg0 == cobra.ShellCompRequestCmd ||
-		arg0 == cobra.ShellCompNoDescRequestCmd {
+	if len(args) > 0 &&
+		(args[0] == "completion" ||
+			args[0] == cobra.ShellCompRequestCmd ||
+			args[0] == cobra.ShellCompNoDescRequestCmd) {
 		return false
 	}
 


### PR DESCRIPTION
hi @marcosnils, I just noticed that my patch is making `bin` crash when invoked without any arguments (should print help instead):

```shell
➜  bin git:(hotfix) bin
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
github.com/marcosnils/bin/cmd.defaultCommand(0xc000004900, {0xc000022050?, 0x0, 0xc000012700?})
	/home/marcos/Projects/bin/cmd/root.go:103 +0x1f2
github.com/marcosnils/bin/cmd.(*rootCmd).Execute(0xc0000112c0, {0xc000022050, 0x0, 0xb4f060?})
	/home/marcos/Projects/bin/cmd/root.go:31 +0x71
github.com/marcosnils/bin/cmd.Execute({0xc00007a230, 0x6b}, 0xdf2220?, {0xc000022050, 0x0, 0x0})
	/home/marcos/Projects/bin/cmd/root.go:25 +0xbb
main.main()
	/home/marcos/Projects/bin/main.go:21 +0x97
➜  bin git:(hotfix) 
```