### PR TITLE
Add support for GITHUB_TOKEN

### DIFF
--- a/pkg/providers/github.go
+++ b/pkg/providers/github.go
@@ -114,6 +114,9 @@ func newGitHub(u *url.URL) (Provider, error) {
 	}
 
 	token := os.Getenv("GITHUB_AUTH_TOKEN")
+	if len(token) == 0 {
+		token = os.Getenv("GITHUB_TOKEN")
+	}
 
 	// GHES client
 	gbu := os.Getenv("GHES_BASE_URL")


### PR DESCRIPTION
Adding support for `GITHUB_TOKEN` environment variable, to respect GitHub's `gh` cli configuration, see here: https://cli.github.com/manual/