### PR TITLE
feat: improves `bin ls` output

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -4,12 +4,20 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strings"
 
-	"github.com/WeiZhang555/tabwriter"
 	"github.com/fatih/color"
 	"github.com/marcosnils/bin/pkg/config"
 	"github.com/spf13/cobra"
 )
+
+// Pad given string with spaces to the right
+func _rPad(s string, width int) string {
+	if len(s) >= width {
+		return s
+	}
+	return s + strings.Repeat(" ", width-len(s))
+}
 
 type listCmd struct {
 	cmd *cobra.Command
@@ -25,19 +33,39 @@ func newListCmd() *listCmd {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			w := new(tabwriter.Writer)
-			w.Init(os.Stdout, 8, 8, 3, '\t', 0)
-
-			defer w.Flush()
-
 			cfg := config.Get()
 
-			fmt.Fprintf(w, "\n %s\t%s\t%s\t%s", "Path", "Version", "URL", "Status")
 			binPaths := []string{}
 			for k := range cfg.Bins {
 				binPaths = append(binPaths, k)
 			}
 			sort.Strings(binPaths)
+
+			// Calculate maximum length of each column
+			maxLengths := make([]int, 3)
+			for _, k := range binPaths {
+				b := cfg.Bins[k]
+				p := os.ExpandEnv(b.Path)
+
+				if len(p) > maxLengths[0] {
+					maxLengths[0] = len(p)
+				}
+
+				if len(b.Version) > maxLengths[1] {
+					maxLengths[1] = len(b.Version)
+				}
+
+				if len(b.URL) > maxLengths[2] {
+					maxLengths[2] = len(b.URL)
+				}
+			}
+
+			pL, vL, uL := maxLengths[0], maxLengths[1], maxLengths[2]
+			magentaItalic := color.New(color.FgMagenta, color.Italic).Sprint
+			p, v, u, s := magentaItalic(_rPad(("Path"), pL)), magentaItalic(_rPad("Version", vL)), magentaItalic(_rPad("URL", uL)), magentaItalic("Status")
+
+			fmt.Printf("\n%s  %s  %s  %s", p, v, u, s)
+
 			for _, k := range binPaths {
 				b := cfg.Bins[k]
 
@@ -50,9 +78,9 @@ func newListCmd() *listCmd {
 					status = color.RedString("missing file")
 				}
 
-				fmt.Fprintf(w, "\n %s\t%s\t%s\t%s", os.ExpandEnv(b.Path), b.Version, b.URL, status)
+				fmt.Printf("\n%s  %s  %s  %s", _rPad(p, pL), _rPad(b.Version, vL), _rPad(b.URL, uL), status)
 			}
-			fmt.Fprintf(w, "\n\n")
+			fmt.Print("\n\n")
 			return nil
 		},
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/marcosnils/bin
 go 1.20
 
 require (
-	github.com/WeiZhang555/tabwriter v0.0.0-20200115015932-e5c45f4da38d
 	github.com/apex/log v1.1.4
 	github.com/cheggaaa/pb v2.0.7+incompatible
 	github.com/coreos/go-semver v0.3.0
@@ -37,7 +36,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.7 // indirect
 	github.com/mattn/go-isatty v0.0.12 // indirect
-	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,6 @@ github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAE
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d/go.mod h1:HI8ITrYtUY+O+ZhtlqUnD8+KwNPOyugEhfP9fdUIaEQ=
-github.com/WeiZhang555/tabwriter v0.0.0-20200115015932-e5c45f4da38d h1:npX89sRvdpLGthK9qEaEeSrgFzgHsTn098UzrssxBp8=
-github.com/WeiZhang555/tabwriter v0.0.0-20200115015932-e5c45f4da38d/go.mod h1:ZTOx+sJkS2TKlfdnrlx3WRWUUWqGCBng2V/ugrPxBRo=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -456,8 +454,6 @@ github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOA
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
-github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
-github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-shellwords v1.0.3/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=


### PR DESCRIPTION
- Using tabs, caused in-consistent spacing across softwares.
- This commit resolves in-consistent tab spacing with simple spaces.