### PR TITLE
command line option select

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,22 @@
+FROM mcr.microsoft.com/devcontainers/go:1-1.22-bookworm
+LABEL version="1.0"
+LABEL maintainer="perplexedpigmy@xmousse.com"
+LABEL description="Go+"
+
+ARG USERNAME=vscode
+
+SHELL ["/bin/bash", "-c"]
+
+RUN \
+  # 
+  # Persist history between different builds
+  SNIPPET="PROMPT_COMMAND='history -a' && export HISTFILE=/cmdhistory/.bash_history"  \
+  && mkdir /cmdhistory  \
+  && touch /cmdhistory/.bash_history  \
+  && chown -R $USERNAME /cmdhistory/.bash_history  \
+  && echo $SNIPPET >> /home/$USERNAME/.bashrc   \
+  #
+  # Cleanups 
+  && apt update -y \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,9 +1,10 @@
 FROM mcr.microsoft.com/devcontainers/go:1-1.22-bookworm
 LABEL version="1.0"
 LABEL maintainer="perplexedpigmy@xmousse.com"
-LABEL description="Go+"
+LABEL description="Go++"
 
 ARG USERNAME=vscode
+ARG BIN_EXE_DIR=/home/${USERNAME}/.local/bin
 
 SHELL ["/bin/bash", "-c"]
 
@@ -16,6 +17,23 @@ RUN \
   && chown -R $USERNAME /cmdhistory/.bash_history  \
   && echo $SNIPPET >> /home/$USERNAME/.bashrc   \
   #
+  && sudo -i -u $USERNAME mkdir -p ${BIN_EXE_DIR} \
+  # Insatll the bin utilit
+  && sudo -i -u $USERNAME wget -O /tmp/bin https://github.com/perplexedpigmy/bin/releases/download/v0.17.5/bin_0.17.5_linux_amd64 \
+  && sudo -i -u $USERNAME chmod a+x /tmp/bin \
+  && sudo -i -u $USERNAME bash -c "BIN_EXE_DIR=${BIN_EXE_DIR} /tmp/bin install github.com/perplexedpigmy/bin" \
+  && sudo -i -u $USERNAME rm /tmp/bin \
+  # 
+  # I
+  && find ${BIN_EXE_DIR} \
+  && sudo -i -u $USERNAME bash -c "BIN_EXE_DIR=${BIN_EXE_DIR} ${BIN_EXE_DIR}/bin install github.com/Wilfred/difftastic" \
+  && sudo -i -u $USERNAME bash -c "BIN_EXE_DIR=${BIN_EXE_DIR} ${BIN_EXE_DIR}/bin install github.com/casey/just -s :just" \
+  && sudo -i -u $USERNAME bash -c "BIN_EXE_DIR=${BIN_EXE_DIR} ${BIN_EXE_DIR}/bin install github.com/ogham/exa -s exa-linux-x86_64-v0.10.1.zip:bin/exa" \
+  && sudo -i -u $USERNAME bash -c "BIN_EXE_DIR=${BIN_EXE_DIR} ${BIN_EXE_DIR}/bin install github.com/sharkdp/bat -s bat-v0.24.0-x86_64-unknown-linux-gnu.tar.gz:bat-v0.24.0-x86_64-unknown-linux-gnu/bat" \
+  && sudo -i -u $USERNAME bash -c "BIN_EXE_DIR=${BIN_EXE_DIR} ${BIN_EXE_DIR}/bin install github.com/mikefarah/yq  -s yq_linux_amd64" \
+  && sudo -i -u $USERNAME bash -c "BIN_EXE_DIR=${BIN_EXE_DIR} ${BIN_EXE_DIR}/bin install github.com/direnv/direnv"  \
+  && sudo -i -u $USERNAME bash -c "BIN_EXE_DIR=${BIN_EXE_DIR} ${BIN_EXE_DIR}/bin install github.com/BurntSushi/ripgrep -s ripgrep-14.1.0-x86_64-unknown-linux-musl.tar.gz:ripgrep-14.1.0-x86_64-unknown-linux-musl/rg" \
+  
   # Cleanups 
   && apt update -y \
   && apt-get clean \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,32 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/go
+{
+	"name": "Go",
+	"build": {	
+		"context": "..", // Sets the run context to one level up instead of the .devcontainer folder.
+		"dockerfile": "Dockerfile"
+	},
+
+	"mounts": [
+		// command history is kept in .devcontainer/.bashrc file
+		"source=./.devcontainer,target=/cmdhistory,type=bind"
+	]
+
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	//"image": "mcr.microsoft.com/devcontainers/go:1-1.22-bookworm"
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "go version",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,16 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/go
+
+//  A go development container with a few addtional tools 
+//  - diffstatic for better diffing 
+//  - just    - a Makefile replacement
+//  - exa     - contempory ls
+//  - bat     - nicer cat
+//  - yq      - json,yaml,csv processor 
+//  - direnv  - automatic local variable loader
+//  - ripgrep - grep for developers
 {
-	"name": "Go",
+	"name": "Go devcontainer ++",
 	"build": {	
 		"context": "..", // Sets the run context to one level up instead of the .devcontainer folder.
 		"dockerfile": "Dockerfile"
@@ -12,21 +21,4 @@
 		"source=./.devcontainer,target=/cmdhistory,type=bind"
 	]
 
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	//"image": "mcr.microsoft.com/devcontainers/go:1-1.22-bookworm"
-
-	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
-
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "go version",
-
-	// Configure tool-specific properties.
-	// "customizations": {},
-
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ bin
 /__debug_bin
 
 dist
+.bash_history

--- a/README.md
+++ b/README.md
@@ -1,113 +1,85 @@
-
 # bin
 
 Manages binary files downloaded from different sources
 
 ![bin](https://user-images.githubusercontent.com/1578458/87901619-ee629a80-ca2d-11ea-8609-8a8eb39801d2.gif)
 
-The original utility is introduced by [Marcos Nils](https://github.com/marcosnils/bin)
-You are invited to visit his [GitHub page](https://github.com/marcosnils/bin) to read the full documentation.
+## Rationale
 
-The repository enables the bin utility to be script-able and avoid requiring TTY user feedback.
+`bin` started as an idea given the popularity of single binary releases due to the surge of  languages like
+Go, Rust, Deno, etc which can easily produce dynamically and statically compiled binarines.
 
-There are 2 minor updates:
-1. Introduction of **BIN_EXE_DIR**
+I found myself downloading binaries (or tarballs) directly from VCS (Github mostly) and then it was hard
+to keep control and update such dependencies whenever a new version was released. So, with the objective
+to solve that problem and also looking for something that will allow me to get the latest releases, I created `bin`.
+In addition to that, I was also looking for something that doesn't require `sudo` or `root` privileges to install
+these binaries as downloading, making them executable and storing it somewhere in your PATH would be sufficient.
 
-Previously, the installation/download directory is derived from the `PATH`, when it's unable to do so, the `bin` utility 
-demands user feedback. In some cases it's useful to be able to shortcut this process and directly provide it with the installation directory using
-the `BIN_EXE_DIR`
+After I finished the first MVP, a friend pointed out that [brew](https://brew.sh) was now supported in linux which almost
+made me abandon the project. After checking out brew (never been an osx user), I found it a bit bloated and seems
+to be doing way more than what I'm actually needing. So, I've decided to continue `bin` and hopefully add more features
+that could result useful to someone else.
+
+If you find `bin` helpful and you have any ideas or suggestions, please create an issue here or send a PR and I'll
+be more than happy to brainstorm about possibilities.
+
+## Installing
+
+1. Download `bin` from the [releases](https://github.com/marcosnils/bin/releases)
+2. Run `./bin install github.com/marcosnils/bin` so `bin` is managed by `bin` itself
+3. Run `bin ls` to make sure bin has been installed correctly. You can now remove the first file you downloaded.
+4. Enjoy!
+
+## Usage
+
+Install a release from github with the following command:
 
 ```shell
-# install `navi` in a specific designated directory, update the bin configuration in the same directory
-$ BIN_EXE_DIR=~/.local/bin bin install github.com/denisidoro/navi
+bin install github.com/kubernetes-sigs/kind # installs latest Kind release
+
+bin install github.com/kubernetes-sigs/kind/releases/tag/v0.8.0 # installs a specific release
+
+bin install github.com/kubernetes-sigs/kind ~/bin/kind # installs latest on a specific path
 ```
 
-**Note:** while the original `bin` utility allows for installation at a specific directory
+You can install Docker images and use them as regular CLIs:
 
 ```shell
-# Explicit install @ ~/.local/bin
-$ bin install github.com/denisidoro/navi  ~/.local/bin
-```
+bin install docker://hashicorp/terraform:light # install the `light` tag for terraform
 
-The behavior differs. Without `BIN_EXE_DIR` when the initial config is missing, the user will be requested to provide the installation directory.
-
-2. Introduction of a command line file option selection (**--select** | **-s** ) 
-
-In some cases the release may contain multiple files and user intervention is required to choose which one to install. The **select** option was introduced to allow 
-the user to specify the exact file to install even when it's inside an archive (tar, xz, etc).
-
-```shell
-SYNTAX:
-   bin install <URL> [ --select | -s  FileName[:ContainedFile] ]
+bin install docker://quay.io/calico/node # install the latest version of calico/node
 ```
 
 ```shell
-# Install the file yq_linux_amd64
-$ bin install github.com/mikefarah/yq --select yq_linux_amd64
-
-# Install broot selecting for the file x86_64-linux that is in the only tar ball existing in the release
-$ bin install github.com/Canop/broot --select :x86_64-linux/broot
-
-# Install the file age/age (age inside a directory with the same name) from the only tarball in the release
-$ bin install github.com/filosottile/age -s :age/age
-
-# Install btm file from the tarball bottom_x86_64-unknown-linux-gnu.tar.gz (select both the tarball and a file)
-$ bin install github.com/ClementTsang/bottom -s bottom_x86_64-unknown-linux-gnu.tar.gz:btm
-
+bin ensure # Ensures that all binaries listed in the configuration are present
+bin help # Help about any command
+bin install <repo> [path] # Downloads the latest binary and makes it executable
+bin list # List current binaries and it's versions
+bin prune # Removes from the DB missing binaries
+bin remove <bin>... # Deletes one or more binaries
+bin update [bin]... # Scans binaries and prompts for update
 ```
 
-While it is possible to select partially, IMHO it defaults my original purpose of avoiding any TTY interaction, but why not?!
+## FAQ
 
-```shell
-# No Selection output 
-$ bin install github.com/ClementTsang/bottom  
-   • Getting latest release for ClementTsang/bottom
+### Can you give some example tools
 
-Multiple matches found, please select one:
+Yes. Following [list](https://github.com/marcosnils/bin/wiki/Tools-list)
 
- [1] bottom_x86_64-unknown-linux-gnu.tar.gz
- [2] bottom_x86_64-unknown-linux-gnu2-17.tar.gz
- [3] bottom_x86_64-unknown-linux-musl.tar.gz
- Select an option: 1
-   • Starting download of https://api.github.com/repos/ClementTsang/bottom/releases/assets/123278270
-1.85 MiB / 1.85 MiB [------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 19.58 MiB p/s 0s
+### There are some bugs and the code is not tested
 
-Multiple matches found, please select one:
+I know... and that's not planning to change any time soon unless I start getting some contributions. I did this as a personal tool and I'll probably be fixing stuff and adding features as I personally need them. Contributions are welcome though and I'll be happy to discuss and review them.
 
- [1] btm
- [2] completion/_btm
- [3] completion/_btm.ps1
- [4] completion/btm.bash
- [5] completion/btm.elv
- [6] completion/btm.fish
- Select an option: 
-```
+### I see releases on Github, but `bin` does not pick them up
 
+At the moment, `bin` does only consider the [latest release from Github](https://docs.github.com/en/rest/reference/repos#get-the-latest-release) according to the following definition:
 
-```shell
-# Partial selection output
-$ bin install github.com/ClementTsang/bottom  -s bottom_x86_64-unknown-linux-gnu.tar.gz
-   • Getting latest release for ClementTsang/bottom
-   • Starting download of https://api.github.com/repos/ClementTsang/bottom/releases/assets/123278270
-1.85 MiB / 1.85 MiB [------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 22.72 MiB p/s 0s
+> The latest release is the most recent non-prerelease, non-draft release, sorted by the `created_at` attribute. The `created_at` attribute is the date of the commit used for the release, and not the date when the release was drafted or published.
 
-Multiple matches found, please select one:
+You _can_ however install a specific pre-release by specifying the URL for the pre-release, e.g. `bin install https://github.com/bufbuild/buf/releases/tag/v0.40.0`.
 
- [1] btm
- [2] completion/_btm
- [3] completion/_btm.ps1
- [4] completion/btm.bash
- [5] completion/btm.elv
- [6] completion/btm.fish
- Select an option: 
- ```
+### I used `bin` and I got rate limited by Github or want to access private repos, what can I do?
 
-```shell
-# Full selection output
-$ bin install github.com/ClementTsang/bottom  -s bottom_x86_64-unknown-linux-gnu.tar.gz:btm
-   • Getting latest release for ClementTsang/bottom
-   • Starting download of https://api.github.com/repos/ClementTsang/bottom/releases/assets/123278270
-1.85 MiB / 1.85 MiB [------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 20.29 MiB p/s 0s
-   • Copying for btm@0.9.6 into /home/vscode/.local/bin/btm
-   • Done installing btm 0.9.6
-```
+Create a Github personal access token by following the steps in this guide: [Creating a personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token). The access token used with `bin` does not need any scopes.
+
+Create an environment variable named `GITHUB_AUTH_TOKEN` with the value of your newly created access token. For example in bash: `export GITHUB_AUTH_TOKEN=<your_token_value>`.

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -19,9 +19,10 @@ type installCmd struct {
 }
 
 type installOpts struct {
-	force    bool
-	provider string
-	all      bool
+	force      bool
+	provider   string
+	all        bool
+	autoSelect string
 }
 
 func newInstallCmd() *installCmd {
@@ -58,7 +59,7 @@ func newInstallCmd() *installCmd {
 				return err
 			}
 
-			pResult, err := p.Fetch(&providers.FetchOpts{All: root.opts.all})
+			pResult, err := p.Fetch(&providers.FetchOpts{All: root.opts.all, AutoSelect: root.opts.autoSelect})
 			if err != nil {
 				return err
 			}
@@ -95,6 +96,7 @@ func newInstallCmd() *installCmd {
 	root.cmd.Flags().BoolVarP(&root.opts.force, "force", "f", false, "Force the installation even if the file already exists")
 	root.cmd.Flags().BoolVarP(&root.opts.all, "all", "a", false, "Show all possible download options (skip scoring & filtering)")
 	root.cmd.Flags().StringVarP(&root.opts.provider, "provider", "p", "", "Forces to use a specific provider")
+	root.cmd.Flags().StringVarP(&root.opts.autoSelect, "select", "s", "", "auto select installation file")
 	return root
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -43,7 +43,7 @@ func ForceInstallationDir() string {
 		return ""
 	}
 
-	if os.MkdirAll(exeDir, 0755); checkDirExistsAndWritable(exeDir) != nil {
+	if err := os.MkdirAll(exeDir, 0755); err != nil && !os.IsExist(err) {
 		return ""
 	}
 
@@ -56,7 +56,7 @@ func CheckAndLoad() error {
 		return err
 	}
 
-	if err := os.Mkdir(configDir, 0755); err != nil && !os.IsExist(err) {
+	if err := os.MkdirAll(configDir, 0755); err != nil && !os.IsExist(err) {
 		return fmt.Errorf("error creating config directory [%v]", err)
 	}
 

--- a/pkg/config/config_unix.go
+++ b/pkg/config/config_unix.go
@@ -17,8 +17,6 @@ import (
 // getDefaultPath reads the user's PATH variable
 // and returns the first directory that's writable by the current
 // user in the system
-// TODO add feature to prompt the user which to select
-// if many paths are found
 func getDefaultPath() (string, error) {
 	penv := os.Getenv("PATH")
 	log.Debugf("User PATH is [%s]", penv)
@@ -40,7 +38,7 @@ func getDefaultPath() (string, error) {
 	// TODO this logic is also duplicated in the windows config. We should
 	// move it to config.go
 	if len(opts) == 0 {
-		return "", errors.New("Automatic path detection didn't return any results")
+		return "", errors.New("automatic path detection didn't return any results")
 	}
 
 	sopts := []fmt.Stringer{}
@@ -57,9 +55,9 @@ func getDefaultPath() (string, error) {
 
 func checkDirExistsAndWritable(dir string) error {
 	if fi, err := os.Stat(dir); err != nil {
-		return fmt.Errorf("Error setting download path [%w]", err)
+		return fmt.Errorf("error setting download path [%w]", err)
 	} else if !fi.IsDir() {
-		return errors.New("Download path is not a directory")
+		return errors.New("download path is not a directory")
 	}
 	// TODO make this work in non unix platforms
 	err := unix.Access(dir, unix.W_OK)

--- a/pkg/providers/github.go
+++ b/pkg/providers/github.go
@@ -50,8 +50,9 @@ func (g *gitHub) Fetch(opts *FetchOpts) (*File, error) {
 		candidates = append(candidates, &assets.Asset{Name: a.GetName(), URL: a.GetURL()})
 	}
 	f := assets.NewFilter(&assets.FilterOpts{SkipScoring: opts.All, PackagePath: opts.PackagePath, SkipPathCheck: opts.SkipPatchCheck, PackageName: opts.PackageName})
+	autoSelect := f.GetAutoSelection(opts.AutoSelect)
 
-	gf, err := f.FilterAssets(g.repo, candidates)
+	gf, err := f.FilterAssets(g.repo, candidates, autoSelect)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/providers/gitlab.go
+++ b/pkg/providers/gitlab.go
@@ -152,8 +152,8 @@ func (g *gitLab) Fetch(opts *FetchOpts) (*File, error) {
 	}
 
 	f := assets.NewFilter(&assets.FilterOpts{SkipScoring: opts.All, PackagePath: opts.PackagePath, SkipPathCheck: opts.SkipPatchCheck})
-
-	gf, err := f.FilterAssets(g.repo, candidates)
+	autoSelect := f.GetAutoSelection(opts.AutoSelect)
+	gf, err := f.FilterAssets(g.repo, candidates, autoSelect)
 	if err != nil {
 		return nil, err
 	}
@@ -173,7 +173,7 @@ func (g *gitLab) Fetch(opts *FetchOpts) (*File, error) {
 	version := release.TagName
 
 	// TODO calculate file hash. Not sure if we can / should do it here
-	// since we don't want to read the file unnecesarily. Additionally, sometimes
+	// since we don't want to read the file unnecessarily. Additionally, sometimes
 	// releases have .sha256 files, so it'd be nice to check for those also
 	file := &File{Data: outFile.Source, Name: outFile.Name, Hash: sha256.New(), Version: version}
 

--- a/pkg/providers/hashicorp.go
+++ b/pkg/providers/hashicorp.go
@@ -98,7 +98,8 @@ func (g *hashiCorp) Fetch(opts *FetchOpts) (*File, error) {
 	}
 
 	f := assets.NewFilter(&assets.FilterOpts{SkipScoring: opts.All, PackagePath: opts.PackagePath, SkipPathCheck: opts.SkipPatchCheck})
-	gf, err := f.FilterAssets(g.repo, candidates)
+	autoSelect := f.GetAutoSelection(opts.AutoSelect)
+	gf, err := f.FilterAssets(g.repo, candidates, autoSelect)
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +112,7 @@ func (g *hashiCorp) Fetch(opts *FetchOpts) (*File, error) {
 	version := release.Version
 
 	// TODO calculate file hash. Not sure if we can / should do it here
-	// since we don't want to read the file unnecesarily. Additionally, sometimes
+	// since we don't want to read the file unnecessarily. Additionally, sometimes
 	// releases have .sha256 files, so it'd be nice to check for those also
 	file := &File{Data: outFile.Source, Name: outFile.Name, Hash: sha256.New(), Version: version}
 

--- a/pkg/providers/providers.go
+++ b/pkg/providers/providers.go
@@ -26,6 +26,7 @@ type FetchOpts struct {
 	PackageName    string
 	PackagePath    string
 	SkipPatchCheck bool
+	AutoSelect     string
 }
 
 type Provider interface {
@@ -36,7 +37,7 @@ type Provider interface {
 	// latest version for this binary
 	GetLatestVersion() (string, string, error)
 
-	// GetID returns the unique identiifer of this provider
+	// GetID returns the unique identifier of this provider
 	GetID() string
 }
 
@@ -70,5 +71,5 @@ func New(u, provider string) (Provider, error) {
 		return newHashiCorp(purl)
 	}
 
-	return nil, fmt.Errorf("Can't find provider for url %s", u)
+	return nil, fmt.Errorf("can't find provider for url %s", u)
 }


### PR DESCRIPTION
I found this `bin` utility useful and wanted to use it inside `Dockefile`s, which meant that at no point can we drop to a TTY,  the simplest way to circumvent user feedback is to allow explicit selection.  This PR suggests a minimal addition required to allow for explicit command line selection as well as a use case in the `.devcontainer` added to the project. It is already being used, the PR is just in case the project maintainer find the added behavior desirable.

**Note:** The README was not updated, as it currently doesn't explain in detail all the options and switches, this oversight can be remedied on request.


There are 2 minor updates:
1. Introduction of **BIN_EXE_DIR**

Previously, the installation/download directory is derived from the `PATH`, when it's unable to do so, the `bin` utility
demands user feedback. In some cases it's useful to be able to shortcut this process and directly provide it with the installation directory using
the `BIN_EXE_DIR`

```shell
# install `navi` in a specific designated directory, update the bin configuration in the same directory
$ BIN_EXE_DIR=~/.local/bin bin install github.com/denisidoro/navi
```

**Note:** while the original `bin` utility allows for installation at a specific directory

```shell
# Explicit install @ ~/.local/bin
$ bin install github.com/denisidoro/navi  ~/.local/bin
```

The behavior differs. Without `BIN_EXE_DIR` when the initial config is missing, the user will be requested to provide the installation directory.

2. Introduction of a command line file option selection (**--select** | **-s** )

In some cases the release may contain multiple files and user intervention is required to choose which one to install. The **select** option was introduced to allow
the user to specify the exact file to install even when it's inside an archive (tar, xz, etc).

```shell
SYNTAX:
   bin install <URL> [ --select | -s  FileName[:ContainedFile] ]
```

```shell
# Install the file yq_linux_amd64
$ bin install github.com/mikefarah/yq --select yq_linux_amd64

# Install broot selecting for the file x86_64-linux that is in the only tar ball existing in the release
$ bin install github.com/Canop/broot --select :x86_64-linux/broot

# Install the file age/age (age inside a directory with the same name) from the only tarball in the release
$ bin install github.com/filosottile/age -s :age/age

# Install btm file from the tarball bottom_x86_64-unknown-linux-gnu.tar.gz (select both the tarball and a file)
$ bin install github.com/ClementTsang/bottom -s bottom_x86_64-unknown-linux-gnu.tar.gz:btm

```

While it is possible to select partially, IMHO it defeats my original purpose of avoiding any TTY interaction, but why not?!

```shell
# No Selection output
$ bin install github.com/ClementTsang/bottom
   • Getting latest release for ClementTsang/bottom

Multiple matches found, please select one:

 [1] bottom_x86_64-unknown-linux-gnu.tar.gz
 [2] bottom_x86_64-unknown-linux-gnu2-17.tar.gz
 [3] bottom_x86_64-unknown-linux-musl.tar.gz
 Select an option: 1
   • Starting download of https://api.github.com/repos/ClementTsang/bottom/releases/assets/123278270
1.85 MiB / 1.85 MiB [------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 19.58 MiB p/s 0s

Multiple matches found, please select one:

 [1] btm
 [2] completion/_btm
 [3] completion/_btm.ps1
 [4] completion/btm.bash
 [5] completion/btm.elv
 [6] completion/btm.fish
 Select an option:
```


```shell
# Partial selection output
$ bin install github.com/ClementTsang/bottom  -s bottom_x86_64-unknown-linux-gnu.tar.gz
   • Getting latest release for ClementTsang/bottom
   • Starting download of https://api.github.com/repos/ClementTsang/bottom/releases/assets/123278270
1.85 MiB / 1.85 MiB [------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 22.72 MiB p/s 0s

Multiple matches found, please select one:

 [1] btm
 [2] completion/_btm
 [3] completion/_btm.ps1
 [4] completion/btm.bash
 [5] completion/btm.elv
 [6] completion/btm.fish
 Select an option:
 ```

```shell
# Full selection output
$ bin install github.com/ClementTsang/bottom  -s bottom_x86_64-unknown-linux-gnu.tar.gz:btm
   • Getting latest release for ClementTsang/bottom
   • Starting download of https://api.github.com/repos/ClementTsang/bottom/releases/assets/123278270
1.85 MiB / 1.85 MiB [------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 20.29 MiB p/s 0s
   • Copying for btm@0.9.6 into /home/vscode/.local/bin/btm
   • Done installing btm 0.9.6
```
