### PR TITLE
initialze `bins` map if it's nil

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -94,6 +94,11 @@ func CheckAndLoad() error {
 		}
 
 	}
+
+	if cfg.Bins == nil {
+		cfg.Bins = map[string]*Binary{}
+	}
+
 	log.Debugf("Download path set to %s", cfg.DefaultPath)
 	return nil
 }


### PR DESCRIPTION
fixes #201

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
