### PR TITLE
Print binary path for asset filtering

### DIFF
--- a/cmd/ensure.go
+++ b/cmd/ensure.go
@@ -76,7 +76,7 @@ func newEnsureCmd() *ensureCmd {
 					return err
 				}
 
-				pResult, err := p.Fetch(&providers.FetchOpts{Version: binCfg.Version})
+				pResult, err := p.Fetch(&providers.FetchOpts{Version: binCfg.Version, LocalPath: binCfg.Path})
 				if err != nil {
 					return err
 				}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -114,7 +114,7 @@ func newUpdateCmd() *updateCmd {
 					return err
 				}
 
-				pResult, err := p.Fetch(&providers.FetchOpts{All: root.opts.all, PackagePath: b.PackagePath, SkipPatchCheck: root.opts.skipPathCheck, PackageName: b.RemoteName})
+				pResult, err := p.Fetch(&providers.FetchOpts{All: root.opts.all, PackagePath: b.PackagePath, SkipPatchCheck: root.opts.skipPathCheck, PackageName: b.RemoteName, LocalPath: b.Path})
 				if err != nil {
 					if root.opts.continueOnError {
 						updateFailures[b] = fmt.Errorf("Error while fetching %v: %w", ui.url, err)

--- a/pkg/assets/assets.go
+++ b/pkg/assets/assets.go
@@ -85,6 +85,7 @@ type FilterOpts struct {
 	// variable to filter the resulting outputs. This is very useful
 	// so we don't prompt the user to pick the file again on updates
 	PackagePath string
+	LocalPath   string
 }
 
 type runtimeResolver struct{}
@@ -201,7 +202,7 @@ func (f *Filter) FilterAssets(repoName string, as []*Asset) (*FilteredAsset, err
 			return generic[i].String() < generic[j].String()
 		})
 
-		choice, err := options.Select("Multiple matches found, please select one:", generic)
+		choice, err := options.Select(fmt.Sprintf("Multiple matches found, please select one for %s:", f.opts.LocalPath), generic)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/providers/github.go
+++ b/pkg/providers/github.go
@@ -52,7 +52,7 @@ func (g *gitHub) Fetch(opts *FetchOpts) (*File, error) {
 	for _, a := range release.Assets {
 		candidates = append(candidates, &assets.Asset{Name: a.GetName(), URL: a.GetURL()})
 	}
-	f := assets.NewFilter(&assets.FilterOpts{SkipScoring: opts.All, PackagePath: opts.PackagePath, SkipPathCheck: opts.SkipPatchCheck, PackageName: opts.PackageName})
+	f := assets.NewFilter(&assets.FilterOpts{SkipScoring: opts.All, PackagePath: opts.PackagePath, SkipPathCheck: opts.SkipPatchCheck, PackageName: opts.PackageName, LocalPath: opts.LocalPath})
 
 	gf, err := f.FilterAssets(g.repo, candidates)
 	if err != nil {

--- a/pkg/providers/providers.go
+++ b/pkg/providers/providers.go
@@ -34,6 +34,7 @@ type FetchOpts struct {
 	PackagePath    string
 	SkipPatchCheck bool
 	Version        string
+	LocalPath      string
 }
 
 type Provider interface {


### PR DESCRIPTION
Sometimes I have to use multiple assets from a release to have that software up and running. For example when using https://github.com/Nukesor/pueue I have to use pueue and pueued.

My issue is, that on update I cannot see whether I have to choose pueued or pueue, often ending up in a state where the server binary is the client binary and vice versa.

Therefore the intention of this PR is to print the binary path to be able to make an informed decision.