### PR TITLE
Feature: Add `go install`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v8
   build:
     runs-on: ubuntu-latest
     steps:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,29 @@
+version: "2"
+linters:
+  settings:
+    errcheck:
+      exclude-functions:
+        - (*os.File).Close  # bin is shortlived cli and will release files on exit
+    staticcheck:
+      checks:
+        - all
+        - -ST1005  # ignore Capitalized errors
+        - -ST1003  # ignore name like Url instread of URL
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/cmd/ensure.go
+++ b/cmd/ensure.go
@@ -75,6 +75,7 @@ func newEnsureCmd() *ensureCmd {
 				if err != nil {
 					return err
 				}
+				log.Debugf("Using provider '%s' for '%s'", p.GetID(), binCfg.URL)
 
 				pResult, err := p.Fetch(&providers.FetchOpts{Version: binCfg.Version})
 				if err != nil {

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -58,6 +58,7 @@ func newInstallCmd() *installCmd {
 			if err != nil {
 				return err
 			}
+			log.Debugf("Using provider '%s' for '%s'", p.GetID(), u)
 
 			pResult, err := p.Fetch(&providers.FetchOpts{All: root.opts.all})
 			if err != nil {

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -135,7 +135,7 @@ func checkFinalPath(path, fileName string) (string, error) {
 func saveToDisk(f *providers.File, path string, overwrite bool) ([]byte, error) {
 	epath := os.ExpandEnv((path))
 
-	var extraFlags int = os.O_EXCL
+	extraFlags := os.O_EXCL
 
 	if overwrite {
 		extraFlags = 0

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -75,7 +75,7 @@ func newListCmd() *listCmd {
 
 				status := color.GreenString("OK")
 				if err != nil {
-					status = color.RedString("missing file")
+					status = color.RedString("missing %s", p)
 				}
 
 				if b.Pinned {

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -38,16 +38,15 @@ func newRemoveCmd() *removeCmd {
 						return err
 					}
 					if os.ExpandEnv(b.Path) == os.ExpandEnv(bp) || p == b.Path {
-						err := os.Remove(os.ExpandEnv(bp))
-						//existingToRemove = append(existingToRemove, b.Path)
+						existingToRemove = append(existingToRemove, b.Path)
+
 						// TODO some providers (like docker) might download
 						// additional things somewhere else, maybe we should
 						// call the provider to do a cleanup here.
-						if err != nil && !os.IsNotExist(err) {
+						if err := os.Remove(os.ExpandEnv(bp)); err != nil && !os.IsNotExist(err) {
 							return fmt.Errorf("Error removing path %s: %v", os.ExpandEnv(bp), err)
 						}
 						continue
-
 					}
 				}
 			}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -76,6 +76,8 @@ func newUpdateCmd() *updateCmd {
 				if err != nil {
 					return err
 				}
+				log.Debugf("Using provider '%s' for '%s'", p.GetID(), b.URL)
+
 				if ui, err := getLatestVersion(b, p); err != nil {
 					if root.opts.continueOnError {
 						updateFailures[b] = fmt.Errorf("Error while getting latest version of %v: %v", b.Path, err)
@@ -117,6 +119,7 @@ func newUpdateCmd() *updateCmd {
 				if err != nil {
 					return err
 				}
+				log.Debugf("Using provider '%s' for '%s'", p.GetID(), ui.url)
 
 				pResult, err := p.Fetch(&providers.FetchOpts{All: root.opts.all, PackagePath: b.PackagePath, SkipPatchCheck: root.opts.skipPathCheck, PackageName: b.RemoteName})
 				if err != nil {

--- a/pkg/providers/goinstall.go
+++ b/pkg/providers/goinstall.go
@@ -1,0 +1,126 @@
+package providers
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/apex/log"
+)
+
+type goinstall struct {
+	name, repo, tag, latestURL string
+}
+
+func parseRepo(path string) (string, string, string, string) {
+	repo := path
+	tag := "latest"
+	if i := strings.LastIndex(path, "@"); i > -1 {
+		repo = filepath.Clean(path[:i])
+		tag = path[i+1:]
+	}
+
+	name := path
+	if i := strings.LastIndex(repo, "/"); i > -1 {
+		name = repo[i+1:]
+	}
+
+	latestURL := fmt.Sprintf("https://proxy.golang.org/%s/@latest", repo)
+
+	return repo, tag, name, latestURL
+}
+
+func newGoInstall(repo string) (Provider, error) {
+	repoUrl := strings.TrimPrefix(repo, "goinstall://")
+	repo, tag, name, latestURL := parseRepo(repoUrl)
+	return &goinstall{repo: repo, tag: tag, name: name, latestURL: latestURL}, nil
+}
+
+func (g *goinstall) Fetch(opts *FetchOpts) (*File, error) {
+
+	if (len(g.tag) > 0 && g.tag != "latest") || len(opts.Version) > 0 {
+		if len(opts.Version) > 0 {
+			// this is used by for the `ensure` command
+			g.tag = opts.Version
+		}
+		log.Infof("Getting %s release for %s", g.tag, g.repo)
+	} else {
+		log.Infof("Getting latest release for %s", g.repo)
+		if name, _, err := g.GetLatestVersion(); err != nil {
+			return nil, fmt.Errorf("failed to get latest version: %w", err)
+		} else {
+			g.tag = name
+		}
+	}
+
+	cmd := exec.Command("go", "install", fmt.Sprintf("%s@%s", g.repo, g.tag))
+
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("failed to install package: %w", err)
+	}
+
+	goBinPath := fmt.Sprintf("%s/bin/%s", os.Getenv("GOPATH"), g.name)
+
+	file, err := os.Open(os.ExpandEnv(goBinPath))
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, file)
+	if err != nil {
+		return nil, err
+	}
+
+	// fixme use tmpdir
+	// Clean go file added in gopath file
+	if err := os.Remove(os.ExpandEnv(goBinPath)); err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("Error removing path %s: %v", os.ExpandEnv(goBinPath), err)
+	}
+
+	return &File{
+		Data:    &buf,
+		Name:    g.name,
+		Version: g.tag,
+	}, nil
+}
+
+func (d *goinstall) GetLatestVersion() (string, string, error) {
+	resp, err := http.Get(d.latestURL)
+	if err != nil {
+		return "", "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", "", err
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return "", "", err
+	}
+
+	version, ok := result["Version"].(string)
+	if !ok {
+		return "", "", fmt.Errorf("version not found in response")
+	}
+
+	return version, d.repo, nil
+}
+
+func (d *goinstall) GetID() string {
+	return "goinstall"
+}

--- a/pkg/providers/goinstall.go
+++ b/pkg/providers/goinstall.go
@@ -42,10 +42,19 @@ func newGoInstall(repo string) (Provider, error) {
 	return &goinstall{repo: repo, tag: tag, name: name, latestURL: latestURL}, nil
 }
 
+func getGoPath() (string, error) {
+	cmd := exec.Command("go", "env", "path")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("command %v failed: %w, output: %s", cmd, err, string(output))
+	}
+	return string(output), nil
+}
+
 func (g *goinstall) Fetch(opts *FetchOpts) (*File, error) {
-	goPath, ok := os.LookupEnv("GOPATH")
-	if !ok {
-		return nil, fmt.Errorf("GOPATH environment variable is mandatory")
+	goPath, err := getGoPath()
+	if err != nil {
+		return nil, err
 	}
 
 	if (len(g.tag) > 0 && g.tag != "latest") || len(opts.Version) > 0 {

--- a/pkg/providers/goinstall.go
+++ b/pkg/providers/goinstall.go
@@ -107,8 +107,8 @@ func (g *goinstall) Fetch(opts *FetchOpts) (*File, error) {
 	}, nil
 }
 
-func (d *goinstall) GetLatestVersion() (string, string, error) {
-	resp, err := http.Get(d.latestURL)
+func (g *goinstall) GetLatestVersion() (string, string, error) {
+	resp, err := http.Get(g.latestURL)
 	if err != nil {
 		return "", "", err
 	}
@@ -129,9 +129,9 @@ func (d *goinstall) GetLatestVersion() (string, string, error) {
 		return "", "", fmt.Errorf("version not found in response")
 	}
 
-	return version, d.repo, nil
+	return version, g.repo, nil
 }
 
-func (d *goinstall) GetID() string {
+func (g *goinstall) GetID() string {
 	return "goinstall"
 }

--- a/pkg/providers/goinstall.go
+++ b/pkg/providers/goinstall.go
@@ -1,7 +1,6 @@
 package providers
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -87,21 +86,11 @@ func (g *goinstall) Fetch(opts *FetchOpts) (*File, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to open path: %w", err)
 	}
-	defer file.Close()
-
-	var buf bytes.Buffer
-	_, err = io.Copy(&buf, file)
-	if err != nil {
-		return nil, err
-	}
-
-	// Clean go file added in gopath file
-	if err := os.Remove(os.ExpandEnv(goBinPath)); err != nil && !os.IsNotExist(err) {
-		return nil, fmt.Errorf("Error removing path %s: %v", os.ExpandEnv(goBinPath), err)
-	}
+	// don't close and keep it for Data, bin is short lived CLI tool
+	// defer file.Close()
 
 	return &File{
-		Data:    &buf,
+		Data:    file,
 		Name:    g.name,
 		Version: g.tag,
 	}, nil

--- a/pkg/providers/goinstall.go
+++ b/pkg/providers/goinstall.go
@@ -42,12 +42,12 @@ func newGoInstall(repo string) (Provider, error) {
 }
 
 func getGoPath() (string, error) {
-	cmd := exec.Command("go", "env", "path")
+	cmd := exec.Command("go", "env", "GOPATH")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("command %v failed: %w, output: %s", cmd, err, string(output))
 	}
-	return string(output), nil
+	return strings.TrimSpace(string(output)), nil
 }
 
 func (g *goinstall) Fetch(opts *FetchOpts) (*File, error) {
@@ -84,7 +84,7 @@ func (g *goinstall) Fetch(opts *FetchOpts) (*File, error) {
 
 	file, err := os.Open(os.ExpandEnv(goBinPath))
 	if err != nil {
-		return nil, fmt.Errorf("failed to open path: %w", err)
+		return nil, fmt.Errorf("failed to open path '%s': %w", goBinPath, err)
 	}
 	// don't close and keep it for Data, bin is short lived CLI tool
 	// defer file.Close()

--- a/pkg/providers/providers.go
+++ b/pkg/providers/providers.go
@@ -8,6 +8,8 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
+
+	"github.com/apex/log"
 )
 
 var ErrInvalidProvider = errors.New("invalid provider")
@@ -49,13 +51,19 @@ type Provider interface {
 }
 
 var (
-	httpUrlPrefix   = regexp.MustCompile("^https?://")
-	dockerUrlPrefix = regexp.MustCompile("^docker://")
+	httpUrlPrefix      = regexp.MustCompile("^https?://")
+	dockerUrlPrefix    = regexp.MustCompile("^docker://")
+	goinstallUrlPrefix = regexp.MustCompile("^goinstall://")
 )
 
 func New(u, provider string) (Provider, error) {
 	if dockerUrlPrefix.MatchString(u) {
+		log.Debugf("Using provider 'docker' for '%s'", u)
 		return newDocker(u)
+	}
+	if goinstallUrlPrefix.MatchString(u) || provider == "goinstall" {
+		log.Debugf("Using provider 'goinstall' for '%s'", u)
+		return newGoInstall(u)
 	}
 	if !httpUrlPrefix.MatchString(u) {
 		u = fmt.Sprintf("https://%s", u)
@@ -67,14 +75,17 @@ func New(u, provider string) (Provider, error) {
 	}
 
 	if strings.Contains(purl.Host, "github") || provider == "github" {
+		log.Debugf("Using provider 'github' for '%s'", u)
 		return newGitHub(purl)
 	}
 
 	if strings.Contains(purl.Host, "gitlab") || provider == "gitlab" {
+		log.Debugf("Using provider 'gitlab' for '%s'", u)
 		return newGitLab(purl)
 	}
 
 	if strings.Contains(purl.Host, "releases.hashicorp.com") || provider == "hashicorp" {
+		log.Debugf("Using provider 'hashicorp' for '%s'", u)
 		return newHashiCorp(purl)
 	}
 

--- a/pkg/providers/providers.go
+++ b/pkg/providers/providers.go
@@ -8,8 +8,6 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
-
-	"github.com/apex/log"
 )
 
 var ErrInvalidProvider = errors.New("invalid provider")
@@ -58,11 +56,9 @@ var (
 
 func New(u, provider string) (Provider, error) {
 	if dockerUrlPrefix.MatchString(u) {
-		log.Debugf("Using provider 'docker' for '%s'", u)
 		return newDocker(u)
 	}
 	if goinstallUrlPrefix.MatchString(u) || provider == "goinstall" {
-		log.Debugf("Using provider 'goinstall' for '%s'", u)
 		return newGoInstall(u)
 	}
 	if !httpUrlPrefix.MatchString(u) {
@@ -75,17 +71,14 @@ func New(u, provider string) (Provider, error) {
 	}
 
 	if strings.Contains(purl.Host, "github") || provider == "github" {
-		log.Debugf("Using provider 'github' for '%s'", u)
 		return newGitHub(purl)
 	}
 
 	if strings.Contains(purl.Host, "gitlab") || provider == "gitlab" {
-		log.Debugf("Using provider 'gitlab' for '%s'", u)
 		return newGitLab(purl)
 	}
 
 	if strings.Contains(purl.Host, "releases.hashicorp.com") || provider == "hashicorp" {
-		log.Debugf("Using provider 'hashicorp' for '%s'", u)
 		return newHashiCorp(purl)
 	}
 


### PR DESCRIPTION
Hello,

Some tools don't provides release via Github and instead uses go install.
This feature check latest release via proxy golang and install tool using local go cmd.

```
$ ./bin install -p goinstall github.com/jrhouston/tfk8s@v0.1.8
   • Getting v0.1.8 release for github.com/jrhouston/tfk8s
   • Copying for tfk8s@v0.1.8 into /home/ahdemir/bin/tfk8s
   • Done installing tfk8s v0.1.8
 
$ ./bin update tfk8s
   • /home/ahdemir/bin/tfk8s v0.1.8 -> v0.1.10 (github.com/jrhouston/tfk8s)
Do you want to continue? [Y/n] y
   • Getting latest release for github.com/jrhouston/tfk8s
   • Copying for tfk8s@v0.1.10 into /home/ahdemir/bin/tfk8s
   • Done updating /home/ahdemir/bin/tfk8s to v0.1.10

$ ./bin remove tfk8s
```

I also had an issue when using remove, since latest release "existingremove" was removed and bin was unable to remove.

I did 3 commits:

* 1 restore existing remove
* 2 explicit error message when path missing
* 3 add goinstall support