### PR TITLE
fix(docker): init client from env variables available to configure do…

### DIFF
--- a/pkg/providers/docker.go
+++ b/pkg/providers/docker.go
@@ -60,12 +60,12 @@ func newDocker(imageURL string) (Provider, error) {
 
 	repo, tag := parseImage(imageURL)
 
-	client, err := client.NewClientWithOpts()
+	c, err := client.NewClientWithOpts(client.FromEnv)
 	if err != nil {
 		return nil, err
 	}
 
-	return &docker{repo: repo, tag: tag, client: client}, nil
+	return &docker{repo: repo, tag: tag, client: c}, nil
 }
 
 // parseImage parses the image returning the repository and tag.


### PR DESCRIPTION
Init docker client from env, so all DOCKER_* envs are respected to configure the client.

I use podman and if i do

```
$ podman system service --time=0 unix://$HOME/.local/podman.sock
$ export DOCKER_HOST="unix://$HOME/.local/podman.sock"
$ bin install docker://nixos/nix
```
it works! So any docker host unix/tcp etc will works too.

Closes #188 