### PR TITLE
Fix list display length with pinned version

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -51,8 +51,12 @@ func newListCmd() *listCmd {
 					maxLengths[0] = len(p)
 				}
 
-				if len(b.Version) > maxLengths[1] {
-					maxLengths[1] = len(b.Version)
+				versionLength := len(b.Version)
+				if b.Pinned {
+					versionLength++ // for the '*' char
+				}
+				if versionLength > maxLengths[1] {
+					maxLengths[1] = versionLength
 				}
 
 				if len(b.URL) > maxLengths[2] {
@@ -79,7 +83,7 @@ func newListCmd() *listCmd {
 				}
 
 				if b.Pinned {
-					fmt.Printf("\n%s  %s  %s  %s", _rPad(p, pL), "*"+_rPad(b.Version, vL), _rPad(b.URL, uL), status)
+					fmt.Printf("\n%s  %s  %s  %s", _rPad(p, pL), _rPad("*"+b.Version, vL), _rPad(b.URL, uL), status)
 					continue
 				}
 


### PR DESCRIPTION
This PR fixes the display column alignment in the `list` command.

When a bin with a pinned version is shown the extra `*` character shift the line ends up misaligned and shifted by 1 character.

### Before

<img width="1106" height="113" alt="image" src="https://github.com/user-attachments/assets/4ce68e00-3602-45d9-acb7-de0ebe6eacdc" />

### After

<img width="1116" height="113" alt="image" src="https://github.com/user-attachments/assets/9a02ab38-d3ad-45ae-8248-2fd1ca061b2c" />
