### PR TITLE
fix(ensure,update): persist provider and path

### DIFF
--- a/cmd/ensure.go
+++ b/cmd/ensure.go
@@ -88,11 +88,13 @@ func newEnsureCmd() *ensureCmd {
 				}
 
 				err = config.UpsertBinary(&config.Binary{
-					RemoteName: pResult.Name,
-					Path:       binCfg.Path,
-					Version:    pResult.Version,
-					Hash:       fmt.Sprintf("%x", hash),
-					URL:        binCfg.URL,
+					RemoteName:  pResult.Name,
+					Path:        binCfg.Path,
+					Version:     pResult.Version,
+					Hash:        fmt.Sprintf("%x", hash),
+					URL:         binCfg.URL,
+					Provider:    p.GetID(),
+					PackagePath: binCfg.PackagePath,
 				})
 				if err != nil {
 					return err

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -141,6 +141,7 @@ func newUpdateCmd() *updateCmd {
 					Version:     pResult.Version,
 					Hash:        fmt.Sprintf("%x", hash),
 					URL:         ui.url,
+					Provider:    p.GetID(),
 					PackagePath: pResult.PackagePath,
 				})
 				if err != nil {


### PR DESCRIPTION
After installing something with `goinstall`, running ensure or update would work once, but never again because the provider wasn't passed through and didn't get re-saved to the `config.json`. Previously, `update` or `ensure` would rewrite the binary's config from its initial post-install URL of `goinstall://module.host/path@ver` to a simple `module.host/path` _without_ passing the `goinstall` provider through, so `bin` would look at a provider-less `module.host/path` and have no idea what to do with it. This just adds two lines that pass the provider through when upserting the binary's config during both `ensure` and `update` commands.

I noticed `PackagePath` was omitted from `ensure` and added that so it gets retained as well (unless its omission was intentional?).

Assisted-by: Claude Sonnet 4.5 via Crush