### PR TITLE
Split config manifest/state and normalize URLs

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -89,7 +89,9 @@ func newInstallCmd() *installCmd {
 				URL:         u,
 				Provider:    p.GetID(),
 				PackagePath: pResult.PackagePath,
+				StateURL:    u,
 			})
+
 			if err != nil {
 				return err
 			}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -140,10 +140,12 @@ func newUpdateCmd() *updateCmd {
 					Path:        b.Path,
 					Version:     pResult.Version,
 					Hash:        fmt.Sprintf("%x", hash),
-					URL:         ui.url,
+					URL:         b.URL,
 					Provider:    p.GetID(),
 					PackagePath: pResult.PackagePath,
+					StateURL:    ui.url,
 				})
+
 				if err != nil {
 					return err
 				}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -38,6 +38,19 @@ type Binary struct {
 	Pinned      bool   `json:"pinned"`
 }
 
+// stateEntry contains per-machine mutable data
+// persisted separately from the manifest
+type stateEntry struct {
+	Version     string `json:"version"`
+	Hash        string `json:"hash"`
+	PackagePath string `json:"package_path"`
+	Pinned      bool   `json:"pinned"`
+}
+
+type state struct {
+	Bins map[string]*stateEntry `json:"bins"`
+}
+
 func CheckAndLoad() error {
 	configPath, err := getConfigPath()
 	if err != nil {
@@ -45,28 +58,48 @@ func CheckAndLoad() error {
 	}
 
 	confDir := filepath.Dir(configPath)
-
-	if err := os.Mkdir(confDir, 0755); err != nil && !os.IsExist(err) {
+	if err := os.MkdirAll(confDir, 0755); err != nil {
 		return fmt.Errorf("Error creating config directory [%v]", err)
 	}
-
 	log.Debugf("Config directory is: %s", confDir)
-	f, err := os.OpenFile(configPath, os.O_RDWR|os.O_CREATE, 0664)
+
+	// Load manifest (may not exist yet)
+	mf, err := os.OpenFile(configPath, os.O_RDWR|os.O_CREATE, 0664)
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
-
-	defer f.Close()
-
-	if err := json.NewDecoder(f).Decode(&cfg); err != nil {
+	defer mf.Close()
+	if err := json.NewDecoder(mf).Decode(&cfg); err != nil {
 		if err == io.EOF {
-			// Empty file and/or was just created, initialize cfg.Bins
 			cfg.Bins = map[string]*Binary{}
 		} else {
 			return err
 		}
 	}
+	if cfg.Bins == nil {
+		cfg.Bins = map[string]*Binary{}
+	}
 
+	// Load state and overlay
+	sp, err := getStatePath(configPath)
+	if err != nil {
+		return err
+	}
+	st := state{Bins: map[string]*stateEntry{}}
+	if sf, err := os.Open(sp); err == nil {
+		defer sf.Close()
+		_ = json.NewDecoder(sf).Decode(&st)
+	}
+	for k, sb := range st.Bins {
+		if b, ok := cfg.Bins[k]; ok && sb != nil {
+			b.Version = sb.Version
+			b.Hash = sb.Hash
+			b.PackagePath = sb.PackagePath
+			b.Pinned = sb.Pinned
+		}
+	}
+
+	// If DefaultPath not set, prompt user and write both files
 	if len(cfg.DefaultPath) == 0 {
 		cfg.DefaultPath, err = getDefaultPath()
 		if err != nil {
@@ -83,7 +116,6 @@ func CheckAndLoad() error {
 
 				if err = checkDirExistsAndWritable(response); err != nil {
 					log.Debugf("Could not set download directory [%s]: [%v]", response, err)
-					// Keep looping until writable and existing dir is selected
 					continue
 				}
 
@@ -92,14 +124,29 @@ func CheckAndLoad() error {
 			}
 		}
 
-		if err := write(); err != nil {
+		if err := writeAll(); err != nil {
 			return err
 		}
-
 	}
 
-	if cfg.Bins == nil {
-		cfg.Bins = map[string]*Binary{}
+	// Migration: if manifest contains state but state file is empty, split
+	needsMigration := false
+	if len(st.Bins) == 0 {
+		for _, b := range cfg.Bins {
+			if b == nil {
+				continue
+			}
+			if b.Version != "" || b.Hash != "" || b.PackagePath != "" || b.Pinned {
+				needsMigration = true
+				break
+			}
+		}
+	}
+	if needsMigration {
+		log.Infof("Splitting config manifest and state into %s and %s", configPath, sp)
+		if err := writeAll(); err != nil {
+			return err
+		}
 	}
 
 	log.Debugf("Download path set to %s", cfg.DefaultPath)
@@ -115,12 +162,10 @@ func Get() *config {
 func UpsertBinary(c *Binary) error {
 	if c != nil {
 		cfg.Bins[c.Path] = c
-		err := write()
-		if err != nil {
+		if err := writeAll(); err != nil {
 			return err
 		}
 	}
-
 	return nil
 }
 
@@ -130,31 +175,90 @@ func RemoveBinaries(paths []string) error {
 	for _, p := range paths {
 		delete(cfg.Bins, p)
 	}
-
-	return write()
+	return writeAll()
 }
 
-func write() error {
+// writeAll writes manifest and state to their respective locations
+func writeAll() error {
 	configPath, err := getConfigPath()
 	if err != nil {
 		return err
 	}
-
-	f, err := os.OpenFile(configPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0664)
+	statePath, err := getStatePath(configPath)
 	if err != nil {
 		return err
 	}
+	if err := writeManifest(configPath); err != nil {
+		return err
+	}
+	if err := writeState(statePath); err != nil {
+		return err
+	}
+	return nil
+}
 
+type manifestConfig struct {
+	DefaultPath string                        `json:"default_path"`
+	Bins        map[string]*manifestBinary    `json:"bins"`
+}
+
+type manifestBinary struct {
+	Path       string `json:"path"`
+	RemoteName string `json:"remote_name"`
+	URL        string `json:"url"`
+	Provider   string `json:"provider"`
+}
+
+func writeManifest(manifestPath string) error {
+	dir := filepath.Dir(manifestPath)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+	f, err := os.OpenFile(manifestPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0664)
+	if err != nil {
+		return err
+	}
 	defer f.Close()
 
-	decoder := json.NewEncoder(f)
-	decoder.SetIndent("", "    ")
-	err = decoder.Encode(cfg)
+	// sanitize state fields out of manifest
+	out := manifestConfig{DefaultPath: cfg.DefaultPath, Bins: map[string]*manifestBinary{}}
+	for k, b := range cfg.Bins {
+		if b == nil {
+			continue
+		}
+		out.Bins[k] = &manifestBinary{
+			Path:       b.Path,
+			RemoteName: b.RemoteName,
+			URL:        b.URL,
+			Provider:   b.Provider,
+		}
+	}
+	enc := json.NewEncoder(f)
+	enc.SetIndent("", "    ")
+	return enc.Encode(out)
+}
+
+func writeState(statePath string) error {
+	dir := filepath.Dir(statePath)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+	f, err := os.OpenFile(statePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0664)
 	if err != nil {
 		return err
 	}
+	defer f.Close()
 
-	return nil
+	st := state{Bins: map[string]*stateEntry{}}
+	for k, b := range cfg.Bins {
+		if b == nil {
+			continue
+		}
+		st.Bins[k] = &stateEntry{Version: b.Version, Hash: b.Hash, PackagePath: b.PackagePath, Pinned: b.Pinned}
+	}
+	enc := json.NewEncoder(f)
+	enc.SetIndent("", "    ")
+	return enc.Encode(st)
 }
 
 // GetArch is the running program's operating system target:
@@ -162,8 +266,6 @@ func write() error {
 func GetArch() []string {
 	res := []string{runtime.GOARCH}
 	if runtime.GOARCH == "amd64" {
-		// Adding x86_64 manually since the uname syscall (man 2 uname)
-		// is not implemented in all systems
 		res = append(res, "x86_64")
 		res = append(res, "x64")
 	}
@@ -175,7 +277,6 @@ func GetArch() []string {
 func GetOS() []string {
 	res := []string{runtime.GOOS}
 	if runtime.GOOS == "windows" {
-		// Adding win since some repositories release with that as the indicator of a windows binary
 		res = append(res, "win")
 	}
 	return res
@@ -183,25 +284,16 @@ func GetOS() []string {
 
 // getConfigPath returns the path to the configuration directory respecting
 // the `XDG Base Directory specification` using the following strategy:
-//   - honor BIN_CONFIG is set
+//   - honor BIN_CONFIG is set (even if not existing yet)
 //   - to prevent breaking of existing configurations, check if "$HOME/.bin/config.json"
 //     exists and return "$HOME/.bin"
 //   - if "XDG_CONFIG_HOME" is set, return "$XDG_CONFIG_HOME/bin"
 //   - if "$HOME/.config" exists, return "$home/.config/bin"
 //   - default to "$HOME/.bin/"
-//
-// ToDo: move the function to config_unix.go and add a similar function for windows,
-//
-//	%APPDATA% might be the right place on windows
 func getConfigPath() (string, error) {
-
 	c := os.Getenv("BIN_CONFIG")
 	if len(c) > 0 {
-		if _, err := os.Stat(c); !os.IsNotExist(err) {
-			return c, nil
-		} else {
-			return "", err
-		}
+		return c, nil
 	}
 
 	home, homeErr := os.UserHomeDir()
@@ -212,10 +304,9 @@ func getConfigPath() (string, error) {
 	}
 
 	c = os.Getenv("XDG_CONFIG_HOME")
-	if _, err := os.Stat(c); !os.IsNotExist(err) {
+	if c != "" {
 		return filepath.Join(c, "bin", "config.json"), nil
 	}
-
 	if homeErr != nil {
 		return "", homeErr
 	}
@@ -223,8 +314,35 @@ func getConfigPath() (string, error) {
 	if _, err := os.Stat(c); !os.IsNotExist(err) {
 		return filepath.Join(c, "bin", "config.json"), nil
 	}
-
 	return filepath.Join(home, ".bin", "config.json"), nil
+}
+
+// getStatePath computes the per-machine state file path derived from manifest path
+func getStatePath(manifestPath string) (string, error) {
+	base := filepath.Base(manifestPath)
+	name := strings.TrimSuffix(base, filepath.Ext(base)) + ".state.json"
+	// Prefer XDG_DATA_HOME
+	if d := os.Getenv("XDG_DATA_HOME"); d != "" {
+		return filepath.Join(d, "bin", name), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	switch runtime.GOOS {
+	case "darwin":
+		return filepath.Join(home, "Library", "Application Support", "bin", name), nil
+	case "windows":
+		if ld := os.Getenv("LOCALAPPDATA"); ld != "" {
+			return filepath.Join(ld, "bin", name), nil
+		}
+		if ad := os.Getenv("APPDATA"); ad != "" {
+			return filepath.Join(ad, "bin", name), nil
+		}
+		return filepath.Join(home, ".local", "share", "bin", name), nil
+	default:
+		return filepath.Join(home, ".local", "share", "bin", name), nil
+	}
 }
 
 func GetOSSpecificExtensions() []string {

--- a/pkg/config/config_unix.go
+++ b/pkg/config/config_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package config
 

--- a/pkg/providers/docker_unix.go
+++ b/pkg/providers/docker_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package providers
 


### PR DESCRIPTION
I use this tool across multiple machines and keep my dotfiles under version control. The problem is that every time I update on one machine and push the dotfiles, the other machines think they already have the latest versions. This happens because the manifest mixes two things that should be separate: the repository list (portable) and the per-machine state (mutable versions).

This PR cleanly separates them. The manifest now contains only the repository names, while the per-machine version state is stored in a separate location. On Linux this follows the XDG spec in ~/.local/share/<app>, and on Windows and macOS it follows their respective standard app-data paths. With this split, one can push git changes to without every update mutating the manifest.

## Summary

- Separate per-machine mutable binary state into its own state file while keeping the manifest minimal and portable.
- Normalize manifest repository URLs to canonical base URLs (e.g., https://github.com/owner/repo) while keeping version-specific release URLs in the state file only.
- Introduce migration logic in CheckAndLoad to automatically split legacy manifests and normalize existing URLs on the first run.