### PR TITLE
support sub-path in goinstall:// (implement same behaviour as go buid)

### DIFF
--- a/pkg/providers/goinstall.go
+++ b/pkg/providers/goinstall.go
@@ -35,8 +35,14 @@ func parseRepo(path string) (string, string, string, string) {
 	return repo, tag, name, latestURL
 }
 
-func baseModulePath(arg string) (string, bool) {
-	noVer := strings.SplitN(arg, "@", 2)[0]
+func moduleRemoveVersion(mod string) string {
+	if i := strings.LastIndex(mod, "@"); i > -1 {
+		return mod[:i]
+	}
+	return mod
+}
+
+func baseModulePath(noVer string) (string, bool) {
 	parts := strings.Split(noVer, "/")
 	for len(parts) > 0 {
 		mod := strings.Join(parts, "/")
@@ -52,8 +58,9 @@ func baseModulePath(arg string) (string, bool) {
 func newGoInstall(repo string) (Provider, error) {
 	repoUrl := strings.TrimPrefix(repo, "goinstall://")
 	subPath := ""
-	baseRepoUrl, found := baseModulePath(repoUrl)
-	subPath = strings.TrimPrefix(repoUrl, baseRepoUrl)
+	repoUrlNoVer := moduleRemoveVersion(repoUrl)
+	baseRepoUrl, found := baseModulePath(repoUrlNoVer)
+	subPath = strings.TrimPrefix(repoUrlNoVer, baseRepoUrl)
 	if found && subPath != "" {
 		repoUrl = baseRepoUrl
 		log.Debugf("Using base module %s with sub path \"%s\"", repoUrl, subPath)

--- a/pkg/providers/goinstall.go
+++ b/pkg/providers/goinstall.go
@@ -14,7 +14,7 @@ import (
 )
 
 type goinstall struct {
-	name, repo, tag, latestURL string
+	name, repo, subPath, tag, latestURL string
 }
 
 func parseRepo(path string) (string, string, string, string) {
@@ -35,10 +35,31 @@ func parseRepo(path string) (string, string, string, string) {
 	return repo, tag, name, latestURL
 }
 
+func baseModulePath(arg string) (string, bool) {
+	noVer := strings.SplitN(arg, "@", 2)[0]
+	parts := strings.Split(noVer, "/")
+	for len(parts) > 0 {
+		mod := strings.Join(parts, "/")
+		out, err := exec.Command("go", "list", "-m", "-f", "{{.Path}}", mod+"@latest").Output()
+		if err == nil {
+			return strings.TrimSpace(string(out)), true
+		}
+		parts = parts[:len(parts)-1]
+	}
+	return "", false
+}
+
 func newGoInstall(repo string) (Provider, error) {
 	repoUrl := strings.TrimPrefix(repo, "goinstall://")
+	subPath := ""
+	baseRepoUrl, found := baseModulePath(repoUrl)
+	subPath = strings.TrimPrefix(repoUrl, baseRepoUrl)
+	if found && subPath != "" {
+		repoUrl = baseRepoUrl
+		log.Debugf("Using base module %s with sub path \"%s\"", repoUrl, subPath)
+	}
 	repo, tag, name, latestURL := parseRepo(repoUrl)
-	return &goinstall{repo: repo, tag: tag, name: name, latestURL: latestURL}, nil
+	return &goinstall{repo: repo, subPath: subPath, tag: tag, name: name, latestURL: latestURL}, nil
 }
 
 func getGoPath() (string, error) {
@@ -71,7 +92,7 @@ func (g *goinstall) Fetch(opts *FetchOpts) (*File, error) {
 		}
 	}
 
-	cmd := exec.Command("go", "install", fmt.Sprintf("%s@%s", g.repo, g.tag))
+	cmd := exec.Command("go", "install", fmt.Sprintf("%s%s@%s", g.repo, g.subPath, g.tag))
 
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
Hi,

this PR adds support for sub-path's in `goinstall://` provider as is supported in `go install` itself too.

It implements the same behaviour as go build to find base module path.
Sadly https://pkg.go.dev/golang.org/x/tools/go/vcs is deprecated, thus this is implemented as recommended via call to `go list`.

The only real downside is, that this PR requires at least one additional external call to `go list` for every pkg that is handled via `goinstall://` even if no subpath is actually used (for actual sub-paths it results in one network call per sub-path component on each invocation).

But we get nice sub-path support
```
% ./bin install --debug goinstall://github.com/mgit-at/godeb/cmd/godeb
  • debug logs enabled, version: dev

  • Config directory is: /home/gebi/.config/bin
  • Download path set to /home/gebi/bin
  • Using base module github.com/mgit-at/godeb with sub path "/cmd/godeb"
^^^ new debug output if base module was found
  • Using provider 'goinstall' for 'goinstall://github.com/mgit-at/godeb/cmd/godeb'
  • Getting latest release for github.com/mgit-at/godeb
  • Copying for godeb@v0.0.0-20251128154812-dd468d8cd01d into /home/gebi/bin/godeb
  • Done installing godeb v0.0.0-20251128154812-dd468d8cd01d
```

Without this PR the call results in an error (`go install` directly works though)
```
% bin install --debug goinstall://github.com/mgit-at/godeb/cmd/godeb
  • debug logs enabled, version: dev

  • Config directory is: /home/gebi/.config/bin
  • Download path set to /home/gebi/bin
  • Using provider 'goinstall' for 'goinstall://github.com/mgit-at/godeb/cmd/godeb'
  • Getting latest release for github.com/mgit-at/godeb/cmd/godeb
  ⨯ command failed                                   error=failed to get latest version: invalid character 'o' in literal null (expecting 'u')
% go install github.com/mgit-at/godeb/cmd/godeb@latest
^^^ works, thus this PR
```

## output of list cmd
```
% ./bin list

Path                          Version                             URL                                             Status
/home/gebi/bin/bin            v0.24.2                             goinstall://github.com/marcosnils/bin           OK
/home/gebi/bin/godeb          v0.0.0-20251128154812-dd468d8cd01d  goinstall://github.com/mgit-at/godeb/cmd/godeb  OK
```

## `bin/config.json` looks fine
```json
        "/home/gebi/bin/godeb": {
            "path": "/home/gebi/bin/godeb",
            "remote_name": "godeb",
            "version": "v0.0.0-20251128154812-dd468d8cd01d",
            "hash": "12596ca928ce8ed94d495ae152b4dc60a532ec3b3157c415bb645ebe3e35b473",
            "url": "goinstall://github.com/mgit-at/godeb/cmd/godeb",
            "provider": "goinstall",
            "package_path": "",
            "pinned": false
        },
```

## update / ensure / remove also works
```
% ./bin update --debug
  • debug logs enabled, version: dev

  • Config directory is: /home/gebi/.config/bin
  • Download path set to /home/gebi/bin
  • Using provider 'goinstall' for 'goinstall://github.com/marcosnils/bin'
  • Checking updates for /home/gebi/bin/bin
  • Using base module github.com/mgit-at/godeb with sub path "/cmd/godeb"
  • Using provider 'goinstall' for 'goinstall://github.com/mgit-at/godeb/cmd/godeb'
  • Checking updates for /home/gebi/bin/godeb
...
% ./bin ensure
% ./bin remove godeb
```