### PR TITLE
Add config option default_chmod to be applied after file creation

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -163,5 +163,20 @@ func saveToDisk(f *providers.File, path string, overwrite bool) ([]byte, error) 
 		return nil, err
 	}
 
+	// chmod the file to be executable using config DefaultChmod if set
+	defaultChmod := config.Get().DefaultChmod
+	if len(defaultChmod) > 0 {
+		var chmodVal int64
+		_, err := fmt.Sscanf(defaultChmod, "%o", &chmodVal)
+		if err != nil {
+			log.Warnf("Could not parse DefaultChmod value '%s', using 0766", defaultChmod)
+			chmodVal = 0o766
+		}
+		err = file.Chmod(os.FileMode(chmodVal))
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return h.Sum(nil), nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,8 +20,9 @@ type config struct {
 	// DefaultPath might not be expanded so it's important that
 	// the caller expands this variable with os.ExpandEnv(string)
 	// if necessary
-	DefaultPath string             `json:"default_path"`
-	Bins        map[string]*Binary `json:"bins"`
+	DefaultPath  string             `json:"default_path"`
+	DefaultChmod string             `json:"default_chmod"`
+	Bins         map[string]*Binary `json:"bins"`
 }
 
 type Binary struct {
@@ -96,6 +97,10 @@ func CheckAndLoad() error {
 			return err
 		}
 
+	}
+
+	if runtime.GOOS == "linux" && len(cfg.DefaultChmod) == 0 {
+		cfg.DefaultChmod = "0766"
 	}
 
 	if cfg.Bins == nil {


### PR DESCRIPTION
I have an unusual umask setup and so the file created was not as expected. Also the default mask value of 0766 was not ideal for me.

I added a new config option `default_chmod` which is applied explicitly as chmod after file creation.
The default value is automatically set to 0766 as it was in the code already, so no apparent change in functionality if this config value is not changed.