### PR TITLE
feat: Add awscli:// provider for installing AWS CLI v2

### DIFF
--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/caarlos0/log"
 	"github.com/marcosnils/bin/pkg/config"
+	"github.com/marcosnils/bin/pkg/providers"
 	"github.com/spf13/cobra"
 )
 
@@ -40,9 +42,16 @@ func newRemoveCmd() *removeCmd {
 					if os.ExpandEnv(b.Path) == os.ExpandEnv(bp) || p == b.Path {
 						existingToRemove = append(existingToRemove, b.Path)
 
-						// TODO some providers (like docker) might download
-						// additional things somewhere else, maybe we should
-						// call the provider to do a cleanup here.
+						// If the provider supports cleanup, call it to remove
+						// supporting files (libraries, completers, etc.)
+						if prov, err := providers.New(b.URL, b.Provider); err == nil {
+							if cleaner, ok := prov.(providers.Cleaner); ok {
+								if err := cleaner.Cleanup(); err != nil {
+									log.Warnf("Provider cleanup failed: %v", err)
+								}
+							}
+						}
+
 						if err := os.Remove(os.ExpandEnv(bp)); err != nil && !os.IsNotExist(err) {
 							return fmt.Errorf("Error removing path %s: %v", os.ExpandEnv(bp), err)
 						}

--- a/pkg/providers/awscli.go
+++ b/pkg/providers/awscli.go
@@ -1,0 +1,276 @@
+package providers
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+
+	"github.com/caarlos0/log"
+	"github.com/hashicorp/go-version"
+	"github.com/marcosnils/bin/pkg/config"
+)
+
+type awsCLI struct {
+	version string // parsed from URL, empty means "latest"
+	tagsURL string // GitHub tags API URL (overridable for testing)
+}
+
+func newAWSCLI(u string) (Provider, error) {
+	raw := strings.TrimPrefix(u, "awscli://")
+	v := strings.TrimSpace(raw)
+	if v == "" || v == "latest" {
+		v = ""
+	}
+	return &awsCLI{
+		version: v,
+		tagsURL: "https://api.github.com/repos/aws/aws-cli/tags",
+	}, nil
+}
+
+func (a *awsCLI) GetID() string {
+	return "awscli"
+}
+
+func (a *awsCLI) GetLatestVersion() (string, string, error) {
+	req, err := http.NewRequest("GET", a.tagsURL+"?per_page=100", nil)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// Use GitHub token if available to avoid rate limits
+	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+		req.Header.Set("Authorization", "token "+token)
+	} else if token := os.Getenv("GITHUB_AUTH_TOKEN"); token != "" {
+		req.Header.Set("Authorization", "token "+token)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to fetch AWS CLI tags: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusTooManyRequests {
+			return "", "", fmt.Errorf("GitHub API rate limit exceeded; set GITHUB_TOKEN to increase limits")
+		}
+		return "", "", fmt.Errorf("GitHub API returned status %d", resp.StatusCode)
+	}
+
+	var tags []struct {
+		Name string `json:"name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&tags); err != nil {
+		return "", "", fmt.Errorf("failed to parse tags response: %w", err)
+	}
+
+	var versions []*version.Version
+	for _, t := range tags {
+		if !strings.HasPrefix(t.Name, "2.") {
+			continue
+		}
+		v, err := version.NewVersion(t.Name)
+		if err != nil {
+			continue
+		}
+		versions = append(versions, v)
+	}
+
+	if len(versions) == 0 {
+		return "", "", fmt.Errorf("no AWS CLI v2 versions found")
+	}
+
+	sort.Sort(version.Collection(versions))
+	latest := versions[len(versions)-1].Original()
+
+	return latest, fmt.Sprintf("awscli://%s", latest), nil
+}
+
+func (a *awsCLI) Fetch(opts *FetchOpts) (*File, error) {
+	// Resolve version
+	ver := a.version
+	if len(opts.Version) > 0 {
+		ver = opts.Version
+	}
+	if ver == "" {
+		log.Infof("Getting latest release for AWS CLI")
+		latest, _, err := a.GetLatestVersion()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get latest version: %w", err)
+		}
+		ver = latest
+	} else {
+		log.Infof("Getting AWS CLI release %s", ver)
+	}
+
+	goos := runtime.GOOS
+	goarch := runtime.GOARCH
+
+	if goos != "linux" && goos != "darwin" {
+		return nil, fmt.Errorf("AWS CLI v2 provider does not support %s", goos)
+	}
+	if goarch != "amd64" && goarch != "arm64" {
+		return nil, fmt.Errorf("AWS CLI v2 provider does not support architecture %s", goarch)
+	}
+
+	// Compute install directory from config default path
+	defaultPath := expandPath(config.Get().DefaultPath)
+	installDir := filepath.Join(filepath.Dir(defaultPath), "lib", "awscli")
+
+	// Build download URL
+	downloadURL, err := buildDownloadURL(ver, goos, goarch)
+	if err != nil {
+		return nil, err
+	}
+
+	// Download to temp file
+	log.Infof("Downloading AWS CLI v2 from %s", downloadURL)
+	tmpFile, err := downloadToTemp(downloadURL)
+	if err != nil {
+		return nil, err
+	}
+	defer os.Remove(tmpFile)
+
+	// Platform-specific install — returns the directory containing the aws/aws_completer binaries
+	binBase, err := installAWSCLI(tmpFile, installDir, goos, ver)
+	if err != nil {
+		return nil, fmt.Errorf("failed to install AWS CLI: %w", err)
+	}
+
+	// Determine real binary paths
+	awsBin := filepath.Join(binBase, "aws")
+	awsCompleter := filepath.Join(binBase, "aws_completer")
+
+	// Verify the install worked
+	if _, err := os.Stat(awsBin); err != nil {
+		return nil, fmt.Errorf("AWS CLI binary not found at %s after installation: %w", awsBin, err)
+	}
+
+	// Create aws_completer wrapper as a side-effect
+	if _, err := os.Stat(awsCompleter); err == nil {
+		completerWrapper := fmt.Sprintf("#!/bin/sh\n# awscli version: %s\nexec \"%s\" \"$@\"\n", ver, awsCompleter)
+		completerPath := filepath.Join(defaultPath, "aws_completer")
+		if err := os.WriteFile(completerPath, []byte(completerWrapper), 0o766); err != nil {
+			log.Warnf("Failed to create aws_completer wrapper at %s: %v", completerPath, err)
+		} else {
+			log.Infof("Created aws_completer wrapper at %s", completerPath)
+		}
+	}
+
+	// Build the aws wrapper script
+	wrapperScript := fmt.Sprintf("#!/bin/sh\n# awscli version: %s\nexec \"%s\" \"$@\"\n", ver, awsBin)
+
+	return &File{
+		Data:    strings.NewReader(wrapperScript),
+		Name:    "aws",
+		Version: ver,
+	}, nil
+}
+
+// Cleanup removes the AWS CLI support directory and aws_completer wrapper.
+func (a *awsCLI) Cleanup() error {
+	defaultPath := expandPath(config.Get().DefaultPath)
+	installDir := filepath.Join(filepath.Dir(defaultPath), "lib", "awscli")
+	completerPath := filepath.Join(defaultPath, "aws_completer")
+
+	if err := os.RemoveAll(installDir); err != nil {
+		log.Warnf("Failed to remove AWS CLI support directory %s: %v", installDir, err)
+	} else {
+		log.Infof("Removed AWS CLI support directory %s", installDir)
+	}
+
+	if err := os.Remove(completerPath); err != nil && !os.IsNotExist(err) {
+		log.Warnf("Failed to remove aws_completer at %s: %v", completerPath, err)
+	} else if err == nil {
+		log.Infof("Removed aws_completer at %s", completerPath)
+	}
+
+	return nil
+}
+
+// buildDownloadURL constructs the AWS CLI download URL for the given version, OS, and architecture.
+func buildDownloadURL(ver, goos, goarch string) (string, error) {
+	const base = "https://awscli.amazonaws.com"
+
+	switch goos {
+	case "linux":
+		arch := "x86_64"
+		if goarch == "arm64" {
+			arch = "aarch64"
+		}
+		if ver != "" {
+			return fmt.Sprintf("%s/awscli-exe-linux-%s-%s.zip", base, arch, ver), nil
+		}
+		return fmt.Sprintf("%s/awscli-exe-linux-%s.zip", base, arch), nil
+
+	case "darwin":
+		if ver != "" {
+			return fmt.Sprintf("%s/AWSCLIV2-%s.pkg", base, ver), nil
+		}
+		return fmt.Sprintf("%s/AWSCLIV2.pkg", base), nil
+
+	default:
+		return "", fmt.Errorf("unsupported OS: %s", goos)
+	}
+}
+
+// downloadToTemp downloads a URL to a temporary file and returns the path.
+func downloadToTemp(url string) (string, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", fmt.Errorf("failed to download %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed to download %s: HTTP %d", url, resp.StatusCode)
+	}
+
+	tmpFile, err := os.CreateTemp("", "awscli-*")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temp file: %w", err)
+	}
+	defer tmpFile.Close()
+
+	if _, err := io.Copy(tmpFile, resp.Body); err != nil {
+		os.Remove(tmpFile.Name())
+		return "", fmt.Errorf("failed to write download: %w", err)
+	}
+
+	return tmpFile.Name(), nil
+}
+
+// expandPath expands both environment variables ($HOME, etc.) and the ~ prefix
+// in a path. os.ExpandEnv only handles $VAR, not ~.
+func expandPath(path string) string {
+	path = os.ExpandEnv(path)
+	if strings.HasPrefix(path, "~/") {
+		if home, err := os.UserHomeDir(); err == nil {
+			path = filepath.Join(home, path[2:])
+		}
+	}
+	return path
+}
+
+// getAWSCLIVersion runs the installed aws binary and extracts the version string.
+// This is used as a fallback to verify the installed version.
+func getAWSCLIVersion(awsBin string) (string, error) {
+	cmd := exec.Command(awsBin, "--version")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	// Output format: "aws-cli/2.15.0 Python/3.11.6 Linux/6.1.0 ..."
+	parts := strings.Fields(string(out))
+	if len(parts) > 0 {
+		return strings.TrimPrefix(parts[0], "aws-cli/"), nil
+	}
+	return "", fmt.Errorf("unexpected aws --version output: %s", string(out))
+}

--- a/pkg/providers/awscli_test.go
+++ b/pkg/providers/awscli_test.go
@@ -1,0 +1,197 @@
+package providers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestNewAWSCLI(t *testing.T) {
+	cases := []struct {
+		name            string
+		url             string
+		expectedVersion string
+	}{
+		{name: "no version", url: "awscli://", expectedVersion: ""},
+		{name: "explicit latest", url: "awscli://latest", expectedVersion: ""},
+		{name: "with version", url: "awscli://2.15.0", expectedVersion: "2.15.0"},
+		{name: "with version spaces", url: "awscli://  2.15.0  ", expectedVersion: "2.15.0"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p, err := newAWSCLI(tc.url)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			a := p.(*awsCLI)
+			if a.version != tc.expectedVersion {
+				t.Errorf("expected version %q, got %q", tc.expectedVersion, a.version)
+			}
+		})
+	}
+}
+
+func TestAWSCLIGetID(t *testing.T) {
+	p, _ := newAWSCLI("awscli://")
+	if p.GetID() != "awscli" {
+		t.Errorf("expected ID 'awscli', got '%s'", p.GetID())
+	}
+}
+
+func TestBuildDownloadURL(t *testing.T) {
+	cases := []struct {
+		name     string
+		version  string
+		goos     string
+		goarch   string
+		expected string
+		wantErr  bool
+	}{
+		{
+			name:     "linux amd64 latest",
+			version:  "",
+			goos:     "linux",
+			goarch:   "amd64",
+			expected: "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip",
+		},
+		{
+			name:     "linux amd64 versioned",
+			version:  "2.15.0",
+			goos:     "linux",
+			goarch:   "amd64",
+			expected: "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.15.0.zip",
+		},
+		{
+			name:     "linux arm64 latest",
+			version:  "",
+			goos:     "linux",
+			goarch:   "arm64",
+			expected: "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip",
+		},
+		{
+			name:     "linux arm64 versioned",
+			version:  "2.0.30",
+			goos:     "linux",
+			goarch:   "arm64",
+			expected: "https://awscli.amazonaws.com/awscli-exe-linux-aarch64-2.0.30.zip",
+		},
+		{
+			name:     "darwin latest",
+			version:  "",
+			goos:     "darwin",
+			goarch:   "arm64",
+			expected: "https://awscli.amazonaws.com/AWSCLIV2.pkg",
+		},
+		{
+			name:     "darwin versioned",
+			version:  "2.15.0",
+			goos:     "darwin",
+			goarch:   "amd64",
+			expected: "https://awscli.amazonaws.com/AWSCLIV2-2.15.0.pkg",
+		},
+		{
+			name:    "unsupported os",
+			version: "",
+			goos:    "windows",
+			goarch:  "amd64",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := buildDownloadURL(tc.version, tc.goos, tc.goarch)
+			if tc.wantErr {
+				if err == nil {
+					t.Error("expected error but got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.expected {
+				t.Errorf("expected %q, got %q", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestGetLatestVersion(t *testing.T) {
+	tags := []struct {
+		Name string `json:"name"`
+	}{
+		{Name: "2.15.0"},
+		{Name: "2.14.6"},
+		{Name: "1.32.0"},
+		{Name: "2.13.0"},
+		{Name: "invalid-tag"},
+		{Name: "2.15.1"},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(tags)
+	}))
+	defer server.Close()
+
+	a := &awsCLI{
+		version: "",
+		tagsURL: server.URL,
+	}
+
+	ver, url, err := a.GetLatestVersion()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ver != "2.15.1" {
+		t.Errorf("expected version '2.15.1', got '%s'", ver)
+	}
+	if url != "awscli://2.15.1" {
+		t.Errorf("expected url 'awscli://2.15.1', got '%s'", url)
+	}
+}
+
+func TestGetLatestVersionNoV2Tags(t *testing.T) {
+	tags := []struct {
+		Name string `json:"name"`
+	}{
+		{Name: "1.32.0"},
+		{Name: "1.31.0"},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(tags)
+	}))
+	defer server.Close()
+
+	a := &awsCLI{
+		version: "",
+		tagsURL: server.URL,
+	}
+
+	_, _, err := a.GetLatestVersion()
+	if err == nil {
+		t.Error("expected error for no v2 tags, got nil")
+	}
+}
+
+func TestGetLatestVersionRateLimit(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	a := &awsCLI{
+		version: "",
+		tagsURL: server.URL,
+	}
+
+	_, _, err := a.GetLatestVersion()
+	if err == nil {
+		t.Error("expected error for rate limit, got nil")
+	}
+}

--- a/pkg/providers/awscli_unix.go
+++ b/pkg/providers/awscli_unix.go
@@ -1,0 +1,284 @@
+//go:build !windows
+
+package providers
+
+import (
+	"archive/zip"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/caarlos0/log"
+)
+
+// installAWSCLI extracts and installs the AWS CLI package to installDir.
+// On Linux, archivePath is a .zip file containing the installer.
+// On macOS, archivePath is a .pkg file.
+// Returns the directory containing the aws and aws_completer binaries.
+func installAWSCLI(archivePath, installDir, goos, version string) (string, error) {
+	if err := os.MkdirAll(installDir, 0o755); err != nil {
+		return "", fmt.Errorf("failed to create install directory %s: %w", installDir, err)
+	}
+
+	switch goos {
+	case "linux":
+		if err := installAWSCLILinux(archivePath, installDir); err != nil {
+			return "", err
+		}
+		// Ensure the "current" symlink points to the version we just installed.
+		// The AWS installer may skip this if the version directory already exists.
+		if err := ensureCurrentSymlink(installDir, version); err != nil {
+			return "", err
+		}
+		// Linux installer creates v2/current/bin/aws
+		return filepath.Join(installDir, "v2", "current", "bin"), nil
+
+	case "darwin":
+		if err := installAWSCLIDarwin(archivePath, installDir); err != nil {
+			return "", err
+		}
+		// macOS pkg has a flat layout: aws and aws_completer are at the root
+		return installDir, nil
+
+	default:
+		return "", fmt.Errorf("unsupported OS for AWS CLI installation: %s", goos)
+	}
+}
+
+// installAWSCLILinux extracts the zip and runs the bundled install script.
+func installAWSCLILinux(zipPath, installDir string) error {
+	// Extract zip to temp directory
+	extractDir, err := os.MkdirTemp("", "awscli-extract-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temp extraction directory: %w", err)
+	}
+	defer os.RemoveAll(extractDir)
+
+	log.Infof("Extracting AWS CLI installer")
+	if err := extractZip(zipPath, extractDir); err != nil {
+		return fmt.Errorf("failed to extract AWS CLI zip: %w", err)
+	}
+
+	// The zip contains an "aws" directory with the install script
+	installScript := filepath.Join(extractDir, "aws", "install")
+	if _, err := os.Stat(installScript); err != nil {
+		return fmt.Errorf("install script not found at %s: %w", installScript, err)
+	}
+
+	// Build install command arguments
+	// --bin-dir points inside the install dir since we create our own wrapper scripts
+	binDir := filepath.Join(installDir, "bin")
+	args := []string{
+		"--install-dir", installDir,
+		"--bin-dir", binDir,
+	}
+
+	// Check if this is an update (install dir already has a version)
+	if _, err := os.Stat(filepath.Join(installDir, "v2")); err == nil {
+		args = append(args, "--update")
+	}
+
+	log.Infof("Running AWS CLI installer")
+	cmd := exec.Command(installScript, args...)
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("AWS CLI installer failed: %w", err)
+	}
+
+	return nil
+}
+
+// installAWSCLIDarwin extracts the .pkg and copies the AWS CLI files to installDir.
+// The macOS .pkg has a flat structure: aws-cli.pkg/Payload/aws-cli/ contains
+// the aws and aws_completer binaries alongside their bundled Python runtime.
+func installAWSCLIDarwin(pkgPath, installDir string) error {
+	expandDir, err := os.MkdirTemp("", "awscli-pkg-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temp directory: %w", err)
+	}
+	defer os.RemoveAll(expandDir)
+
+	expandTarget := filepath.Join(expandDir, "awscli")
+
+	log.Infof("Expanding AWS CLI package")
+	cmd := exec.Command("pkgutil", "--expand-full", pkgPath, expandTarget)
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to expand .pkg: %w", err)
+	}
+
+	// The expanded .pkg contains: aws-cli.pkg/Payload/aws-cli/{aws,aws_completer,Python,...}
+	payloadDir, err := findAWSPayload(expandTarget)
+	if err != nil {
+		return fmt.Errorf("failed to locate AWS CLI payload in expanded .pkg: %w", err)
+	}
+
+	log.Infof("Installing AWS CLI files to %s", installDir)
+	if err := copyDir(payloadDir, installDir); err != nil {
+		return fmt.Errorf("failed to copy AWS CLI files: %w", err)
+	}
+
+	return nil
+}
+
+// findAWSPayload searches the expanded pkg directory for the AWS CLI payload.
+// It looks for the "aws" executable within the directory tree.
+func findAWSPayload(expandedDir string) (string, error) {
+	// Known .pkg payload path: aws-cli.pkg/Payload/aws-cli/
+	// The aws binary lives directly in this directory (flat layout, no v2/current/bin/).
+	candidate := filepath.Join(expandedDir, "aws-cli.pkg", "Payload", "aws-cli")
+	if _, err := os.Stat(filepath.Join(candidate, "aws")); err == nil {
+		return candidate, nil
+	}
+
+	// Fallback: walk the directory to find the aws executable
+	var found string
+	filepath.Walk(expandedDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if info.Name() == "aws" && !info.IsDir() && info.Mode()&0o111 != 0 {
+			// Found an executable named "aws"; use its parent directory
+			found = filepath.Dir(path)
+			return filepath.SkipAll
+		}
+		return nil
+	})
+
+	if found != "" {
+		return found, nil
+	}
+
+	return "", fmt.Errorf("could not find AWS CLI payload in %s", expandedDir)
+}
+
+// extractZip extracts a zip file to the destination directory.
+func extractZip(zipPath, destDir string) error {
+	r, err := zip.OpenReader(zipPath)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	for _, f := range r.File {
+		target := filepath.Join(destDir, f.Name)
+
+		// Prevent zip slip
+		cleanDest := filepath.Clean(destDir) + string(os.PathSeparator)
+		if !strings.HasPrefix(filepath.Clean(target)+string(os.PathSeparator), cleanDest) && filepath.Clean(target) != filepath.Clean(destDir) {
+			return fmt.Errorf("invalid zip entry: %s", f.Name)
+		}
+
+		if f.FileInfo().IsDir() {
+			if err := os.MkdirAll(target, f.Mode()); err != nil {
+				return err
+			}
+			continue
+		}
+
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+
+		outFile, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
+		if err != nil {
+			return err
+		}
+
+		rc, err := f.Open()
+		if err != nil {
+			outFile.Close()
+			return err
+		}
+
+		_, err = io.Copy(outFile, rc)
+		rc.Close()
+		outFile.Close()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// copyDir recursively copies a directory tree, preserving symlinks.
+func copyDir(src, dst string) error {
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+
+		if info.IsDir() {
+			return os.MkdirAll(target, info.Mode())
+		}
+
+		// Handle symlinks
+		if info.Mode()&os.ModeSymlink != 0 {
+			link, err := os.Readlink(path)
+			if err != nil {
+				return err
+			}
+			os.Remove(target) // remove existing if any
+			return os.Symlink(link, target)
+		}
+
+		return copyFile(path, target, info.Mode())
+	})
+}
+
+// ensureCurrentSymlink ensures the v2/current symlink points to the given version.
+// This handles the case where the AWS installer skips because the version dir already exists.
+func ensureCurrentSymlink(installDir, version string) error {
+	if version == "" {
+		return nil
+	}
+
+	versionDir := filepath.Join(installDir, "v2", version)
+	if _, err := os.Stat(versionDir); err != nil {
+		// Version directory doesn't exist; the installer should have created it.
+		// If it didn't, something went wrong, but we can't fix it here.
+		return nil
+	}
+
+	currentLink := filepath.Join(installDir, "v2", "current")
+
+	// Read current symlink target
+	target, err := os.Readlink(currentLink)
+	if err == nil && target == version {
+		return nil // already correct
+	}
+
+	// Remove existing symlink/file and create new one
+	os.Remove(currentLink)
+	return os.Symlink(version, currentLink)
+}
+
+// copyFile copies a single file.
+func copyFile(src, dst string, mode os.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, in)
+	return err
+}

--- a/pkg/providers/providers.go
+++ b/pkg/providers/providers.go
@@ -48,10 +48,20 @@ type Provider interface {
 	GetID() string
 }
 
+// Cleaner is an optional interface that providers can implement to perform
+// cleanup when a binary is removed. This allows providers that install
+// supporting files (libraries, completers, etc.) to clean up after themselves.
+type Cleaner interface {
+	// Cleanup removes any supporting files or directories installed by the provider.
+	// It should log warnings for non-critical failures rather than returning errors.
+	Cleanup() error
+}
+
 var (
 	httpUrlPrefix      = regexp.MustCompile("^https?://")
 	dockerUrlPrefix    = regexp.MustCompile("^docker://")
 	goinstallUrlPrefix = regexp.MustCompile("^goinstall://")
+	awscliUrlPrefix    = regexp.MustCompile("^awscli://")
 )
 
 func New(u, provider string) (Provider, error) {
@@ -60,6 +70,9 @@ func New(u, provider string) (Provider, error) {
 	}
 	if goinstallUrlPrefix.MatchString(u) || provider == "goinstall" {
 		return newGoInstall(u)
+	}
+	if awscliUrlPrefix.MatchString(u) || provider == "awscli" {
+		return newAWSCLI(u)
 	}
 	if !httpUrlPrefix.MatchString(u) {
 		u = fmt.Sprintf("https://%s", u)


### PR DESCRIPTION
Add a new provider that installs AWS CLI v2 via `bin install awscli://[version]`, supporting Linux (amd64/arm64) and macOS. The provider downloads and runs the official AWS installer, creates wrapper scripts for aws and aws_completer, and discovers latest versions via the GitHub tags API.

Also adds an optional Cleaner interface so providers can clean up supporting files on `bin remove`, and implements it for awscli to remove the lib directory and aws_completer wrapper.

Closes #263