### PR TITLE
feat: improve arch/os matching and filter non-installable release files

### DIFF
--- a/pkg/assets/assets.go
+++ b/pkg/assets/assets.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -27,6 +28,35 @@ import (
 var (
 	msiType = filetype.AddType("msi", "application/octet-stream")
 	ascType = filetype.AddType("asc", "text/plain")
+
+	metadataSuffixes = []string{
+		".sha256", ".sha512", ".sha1", ".md5",
+		".sha256sum", ".sha512sum",
+		".sig", ".minisig", ".pem", ".crt", ".cer", ".asc",
+	}
+
+	metadataTokens = []string{
+		"checksum", "sha256sum", "sha512sum",
+	}
+
+	archiveJunkSuffixes = []string{
+		".md", ".markdown", ".rst", ".adoc", ".txt", ".rtf",
+		".html", ".htm", ".pdf",
+		".png", ".jpg", ".jpeg", ".gif", ".svg",
+		".yml", ".yaml", ".json", ".toml", ".ini",
+		".example", ".sample",
+	}
+
+	archiveJunkBaseNames = []string{
+		"license", "copying", "notice",
+		"readme", "changelog", "changes", "news",
+		"authors", "contributors", "contributing",
+		"installation",
+	}
+
+	archiveJunkDirs = []string{
+		"/autocomplete/", "/completions/",
+	}
 )
 
 type Asset struct {
@@ -118,6 +148,8 @@ func NewFilter(opts *FilterOpts) *Filter {
 // select the proper one and ask the user to manually select one
 // in case it can't determine it
 func (f *Filter) FilterAssets(repoName string, as []*Asset) (*FilteredAsset, error) {
+	as = filterInstallableAssets(as)
+
 	matches := []*FilteredAsset{}
 	if len(as) == 1 {
 		a := as[0]
@@ -219,37 +251,79 @@ func (f *Filter) FilterAssets(repoName string, as []*Asset) (*FilteredAsset, err
 func SanitizeName(name, version string) string {
 	name = strings.ToLower(name)
 	replacements := []string{}
+	separators := []string{"_", "-", "."}
+	innerSeparators := []string{"_", "-", "."}
+
+	osNames := appendUnique(
+		resolver.GetOS(),
+		"darwin", "macos", "osx", "apple",
+		"linux",
+		"windows", "win",
+		"freebsd", "openbsd", "netbsd", "dragonfly",
+		"android",
+	)
+	archNames := appendUnique(
+		resolver.GetArch(),
+		"amd64", "x86_64", "x64",
+		"arm64", "aarch64", "armv7", "armv6", "arm",
+		"386", "i386", "x86",
+	)
 
 	// TODO maybe instead of doing this put everything in a map (set) and then
 	// generate the replacements? IDK.
-	firstPass := true
-	for _, osName := range resolver.GetOS() {
-		for _, archName := range resolver.GetArch() {
-			replacements = append(replacements, "_"+osName+archName, "")
-			replacements = append(replacements, "-"+osName+archName, "")
-			replacements = append(replacements, "."+osName+archName, "")
-
-			if firstPass {
-				replacements = append(replacements, "_"+archName, "")
-				replacements = append(replacements, "-"+archName, "")
-				replacements = append(replacements, "."+archName, "")
+	for _, osName := range osNames {
+		for _, archName := range archNames {
+			for _, sep := range separators {
+				replacements = append(replacements, sep+osName+archName, "")
+				replacements = append(replacements, sep+archName+osName, "")
+				for _, innerSep := range innerSeparators {
+					replacements = append(replacements, sep+osName+innerSep+archName, "")
+					replacements = append(replacements, sep+archName+innerSep+osName, "")
+				}
 			}
 		}
 
-		replacements = append(replacements, "_"+osName, "")
-		replacements = append(replacements, "-"+osName, "")
-		replacements = append(replacements, "."+osName, "")
-
-		firstPass = false
-
+		for _, sep := range separators {
+			replacements = append(replacements, sep+osName, "")
+		}
 	}
 
-	replacements = append(replacements, "_"+version, "")
-	replacements = append(replacements, "_"+strings.TrimPrefix(version, "v"), "")
-	replacements = append(replacements, "-"+version, "")
-	replacements = append(replacements, "-"+strings.TrimPrefix(version, "v"), "")
+	for _, archName := range archNames {
+		for _, sep := range separators {
+			replacements = append(replacements, sep+archName, "")
+		}
+	}
+
+	trimmedVersion := strings.TrimPrefix(strings.ToLower(version), "v")
+	for _, sep := range separators {
+		replacements = append(replacements, sep+trimmedVersion, "")
+		replacements = append(replacements, sep+"v"+trimmedVersion, "")
+	}
+
 	r := strings.NewReplacer(replacements...)
-	return r.Replace(name)
+	name = r.Replace(name)
+	name = strings.Trim(name, "._-")
+	name = strings.ReplaceAll(name, "__", "_")
+	name = strings.ReplaceAll(name, "--", "-")
+	name = strings.ReplaceAll(name, "..", ".")
+	return strings.Trim(name, "._-")
+}
+
+func appendUnique(values []string, additions ...string) []string {
+	out := make([]string, 0, len(values)+len(additions))
+	seen := map[string]struct{}{}
+	for _, v := range append(values, additions...) {
+		v = strings.ToLower(v)
+		if v == "" {
+			continue
+		}
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	return out
 }
 
 // ProcessURL processes a FilteredAsset by uncompressing/unarchiving the URL of the asset.
@@ -385,6 +459,7 @@ func (f *Filter) processTar(name string, r io.Reader) (*finalFile, error) {
 	for f := range tarFiles {
 		as = append(as, &Asset{Name: f, URL: ""})
 	}
+	as = filterArchiveAssets(as)
 	choice, err := f.FilterAssets(name, as)
 	if err != nil {
 		return nil, err
@@ -451,6 +526,7 @@ func (f *Filter) processZip(name string, r io.Reader) (*finalFile, error) {
 	for f := range zipFiles {
 		as = append(as, &Asset{Name: f, URL: ""})
 	}
+	as = filterArchiveAssets(as)
 	choice, err := f.FilterAssets(name, as)
 	if err != nil {
 		return nil, err
@@ -481,4 +557,79 @@ func isSupportedExt(filename string) bool {
 	}
 
 	return true
+}
+
+// filterAssetsBy removes assets matching the skip predicate, falling back to
+// the original list if every asset would be removed.
+func filterAssetsBy(as []*Asset, skip func(name string) bool, label string) []*Asset {
+	filtered := make([]*Asset, 0, len(as))
+	for _, a := range as {
+		if skip(a.Name) {
+			log.Debugf("Skipping %s asset %s", label, a.Name)
+			continue
+		}
+		filtered = append(filtered, a)
+	}
+
+	if len(filtered) == 0 {
+		log.Debugf("All %d assets matched %s filter, keeping original list", len(as), label)
+		return as
+	}
+	return filtered
+}
+
+func filterInstallableAssets(as []*Asset) []*Asset {
+	return filterAssetsBy(as, looksLikeMetadataAsset, "metadata")
+}
+
+func filterArchiveAssets(as []*Asset) []*Asset {
+	return filterAssetsBy(as, func(name string) bool {
+		return looksLikeMetadataAsset(name) || looksLikeArchiveJunk(name)
+	}, "non-binary archive")
+}
+
+func looksLikeMetadataAsset(name string) bool {
+	lower := strings.ToLower(name)
+
+	if bstrings.HasAnySuffix(lower, metadataSuffixes) {
+		return true
+	}
+
+	return bstrings.ContainsAny(lower, metadataTokens)
+}
+
+func looksLikeArchiveJunk(name string) bool {
+	normalized := strings.ToLower(strings.ReplaceAll(name, "\\", "/"))
+	base := path.Base(normalized)
+
+	if bstrings.ContainsAny(normalized, archiveJunkDirs) {
+		return true
+	}
+
+	if bstrings.HasAnySuffix(base, archiveJunkSuffixes) {
+		return true
+	}
+
+	ext := path.Ext(base)
+	if looksLikeManPageExt(ext) {
+		return true
+	}
+
+	stem := strings.TrimSuffix(base, ext)
+	for _, junk := range archiveJunkBaseNames {
+		if stem == junk || strings.HasPrefix(stem, junk+"-") || strings.HasPrefix(stem, junk+"_") {
+			return true
+		}
+	}
+
+	return false
+}
+
+func looksLikeManPageExt(ext string) bool {
+	if len(ext) != 2 {
+		return false
+	}
+
+	ch := ext[1]
+	return ext[0] == '.' && ch >= '1' && ch <= '9'
 }

--- a/pkg/assets/assets_test.go
+++ b/pkg/assets/assets_test.go
@@ -27,6 +27,7 @@ func (m *mockOSResolver) GetOSSpecificExtensions() []string {
 var (
 	testLinuxAMDResolver   = &mockOSResolver{OS: []string{"linux"}, Arch: []string{"amd64", "x86_64", "x64", "64"}, OSSpecificExtensions: []string{"AppImage"}}
 	testWindowsAMDResolver = &mockOSResolver{OS: []string{"windows", "win"}, Arch: []string{"amd64", "x86_64", "x64", "64"}, OSSpecificExtensions: []string{"exe"}}
+	testDarwinARMResolver  = &mockOSResolver{OS: []string{"darwin", "macos", "osx"}, Arch: []string{"arm64", "aarch64"}}
 )
 
 func TestSanitizeName(t *testing.T) {
@@ -44,6 +45,7 @@ func TestSanitizeName(t *testing.T) {
 		{"launchpad-linux-x64", "1.2.0-rc.1", "launchpad", testLinuxAMDResolver},
 		{"launchpad-win-x64.exe", "1.2.0-rc.1", "launchpad.exe", testWindowsAMDResolver},
 		{"bin_0.0.1_Windows_x86_64.exe", "0.0.1", "bin.exe", testWindowsAMDResolver},
+		{"dummyhttp-1.1.3-aarch64-apple-darwin", "v1.1.3", "dummyhttp", testDarwinARMResolver},
 	}
 
 	for _, c := range cases {
@@ -147,6 +149,17 @@ func TestFilterAssets(t *testing.T) {
 		{args{"cli", []*Asset{
 			{Name: "dapr", URL: ""},
 		}}, "dapr", testLinuxAMDResolver},
+		{args{"mytool", []*Asset{
+			{Name: "mytool-v1.0.0-aarch64-apple-darwin.tar.gz", URL: "https://example.com/mytool-v1.0.0-aarch64-apple-darwin.tar.gz"},
+			{Name: "mytool-v1.0.0-aarch64-apple-darwin.tar.gz.sha256", URL: "https://example.com/mytool-v1.0.0-aarch64-apple-darwin.tar.gz.sha256"},
+			{Name: "mytool-v1.0.0-x86_64-apple-darwin.tar.gz", URL: "https://example.com/mytool-v1.0.0-x86_64-apple-darwin.tar.gz"},
+			{Name: "mytool-v1.0.0-x86_64-apple-darwin.tar.gz.sha256", URL: "https://example.com/mytool-v1.0.0-x86_64-apple-darwin.tar.gz.sha256"},
+		}}, "mytool-v1.0.0-aarch64-apple-darwin.tar.gz", testDarwinARMResolver},
+		{args{"mytool", []*Asset{
+			{Name: "mytool-linux-aarch64-musl.zip", URL: "https://example.com/mytool-linux-aarch64-musl.zip"},
+			{Name: "mytool-linux-aarch64.zip", URL: "https://example.com/mytool-linux-aarch64.zip"},
+			{Name: "mytool-macos-aarch64.zip", URL: "https://example.com/mytool-macos-aarch64.zip"},
+		}}, "mytool-macos-aarch64.zip", testDarwinARMResolver},
 	}
 
 	f := NewFilter(&FilterOpts{SkipScoring: false})
@@ -162,6 +175,174 @@ func TestFilterAssets(t *testing.T) {
 		}
 	}
 
+}
+
+func TestLooksLikeMetadataAsset(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		out  bool
+	}{
+		{
+			name: "sha256 suffix",
+			in:   "tool-darwin-aarch64.tar.gz.sha256",
+			out:  true,
+		},
+		{
+			name: "checksums token",
+			in:   "checksums.txt",
+			out:  true,
+		},
+		{
+			name: "binary archive",
+			in:   "tool-darwin-aarch64.tar.gz",
+			out:  false,
+		},
+	}
+
+	for _, c := range cases {
+		result := looksLikeMetadataAsset(c.in)
+		if result != c.out {
+			t.Fatalf("%s: expected %v, got %v", c.name, c.out, result)
+		}
+	}
+}
+
+func TestLooksLikeArchiveJunk(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		out  bool
+	}{
+		{
+			name: "readme markdown",
+			in:   "mytool-1.0.0-darwin-arm64/README.md",
+			out:  true,
+		},
+		{
+			name: "license with no extension",
+			in:   "mytool-1.0.0-darwin-arm64/LICENSE",
+			out:  true,
+		},
+		{
+			name: "license with suffix",
+			in:   "mytool-v1.0.0-aarch64-apple-darwin/LICENSE-MIT",
+			out:  true,
+		},
+		{
+			name: "autocomplete file",
+			in:   "mytool-v1.0.0-aarch64-apple-darwin/autocomplete/_mytool",
+			out:  true,
+		},
+		{
+			name: "man page",
+			in:   "mytool-v1.0.0-aarch64-apple-darwin/mytool.1",
+			out:  true,
+		},
+		{
+			name: "binary without extension",
+			in:   "mytool-1.0.0-darwin-arm64/mytool",
+			out:  false,
+		},
+		{
+			name: "windows binary",
+			in:   "tool/windows/tool.exe",
+			out:  false,
+		},
+		{
+			name: "backslash path license",
+			in:   "tool-1.0\\LICENSE",
+			out:  true,
+		},
+		{
+			name: "backslash path binary",
+			in:   "tool-1.0\\tool",
+			out:  false,
+		},
+		{
+			name: "completions directory",
+			in:   "tool-1.0/completions/tool.bash",
+			out:  true,
+		},
+	}
+
+	for _, c := range cases {
+		result := looksLikeArchiveJunk(c.in)
+		if result != c.out {
+			t.Fatalf("%s: expected %v, got %v", c.name, c.out, result)
+		}
+	}
+}
+
+func TestFilterArchiveAssets(t *testing.T) {
+	as := []*Asset{
+		{Name: "mytool-1.0.0-darwin-arm64/LICENSE"},
+		{Name: "mytool-1.0.0-darwin-arm64/README.md"},
+		{Name: "mytool-1.0.0-darwin-arm64/mytool"},
+	}
+
+	filtered := filterArchiveAssets(as)
+	if len(filtered) != 1 {
+		t.Fatalf("expected 1 archive candidate, got %d (%v)", len(filtered), filtered)
+	}
+	if filtered[0].Name != "mytool-1.0.0-darwin-arm64/mytool" {
+		t.Fatalf("unexpected selected archive candidate %s", filtered[0].Name)
+	}
+}
+
+func TestFilterArchiveAssetsComplexLayout(t *testing.T) {
+	as := []*Asset{
+		{Name: "mytool-v1.0.0-aarch64-apple-darwin/CHANGELOG.md"},
+		{Name: "mytool-v1.0.0-aarch64-apple-darwin/LICENSE-APACHE"},
+		{Name: "mytool-v1.0.0-aarch64-apple-darwin/LICENSE-MIT"},
+		{Name: "mytool-v1.0.0-aarch64-apple-darwin/README.md"},
+		{Name: "mytool-v1.0.0-aarch64-apple-darwin/autocomplete/_mytool"},
+		{Name: "mytool-v1.0.0-aarch64-apple-darwin/autocomplete/_mytool.ps1"},
+		{Name: "mytool-v1.0.0-aarch64-apple-darwin/autocomplete/mytool.bash"},
+		{Name: "mytool-v1.0.0-aarch64-apple-darwin/autocomplete/mytool.fish"},
+		{Name: "mytool-v1.0.0-aarch64-apple-darwin/mytool"},
+		{Name: "mytool-v1.0.0-aarch64-apple-darwin/mytool.1"},
+	}
+
+	filtered := filterArchiveAssets(as)
+	if len(filtered) != 1 {
+		t.Fatalf("expected 1 archive candidate, got %d (%v)", len(filtered), filtered)
+	}
+	if filtered[0].Name != "mytool-v1.0.0-aarch64-apple-darwin/mytool" {
+		t.Fatalf("unexpected selected archive candidate %s", filtered[0].Name)
+	}
+}
+
+func TestFilterArchiveAssetsAllFiltered(t *testing.T) {
+	as := []*Asset{
+		{Name: "pkg/README.md"},
+		{Name: "pkg/LICENSE"},
+	}
+
+	filtered := filterArchiveAssets(as)
+	if len(filtered) != len(as) {
+		t.Fatalf("expected fallback to original list (%d items), got %d", len(as), len(filtered))
+	}
+}
+
+func TestLooksLikeManPageExt(t *testing.T) {
+	cases := []struct {
+		in  string
+		out bool
+	}{
+		{in: ".1", out: true},
+		{in: ".8", out: true},
+		{in: ".0", out: false},
+		{in: ".md", out: false},
+		{in: ".10", out: false},
+	}
+
+	for _, c := range cases {
+		result := looksLikeManPageExt(c.in)
+		if result != c.out {
+			t.Fatalf("ext %s: expected %v, got %v", c.in, c.out, result)
+		}
+	}
 }
 
 func TestIsSupportedExt(t *testing.T) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -161,11 +161,15 @@ func write() error {
 // one of darwin, freebsd, linux, and so on.
 func GetArch() []string {
 	res := []string{runtime.GOARCH}
-	if runtime.GOARCH == "amd64" {
+	switch runtime.GOARCH {
+	case "amd64":
 		// Adding x86_64 manually since the uname syscall (man 2 uname)
 		// is not implemented in all systems
 		res = append(res, "x86_64")
 		res = append(res, "x64")
+	case "arm64":
+		// Many release assets (especially on macOS) use aarch64
+		res = append(res, "aarch64")
 	}
 	return res
 }
@@ -174,7 +178,11 @@ func GetArch() []string {
 // one of 386, amd64, arm, s390x, and so on.
 func GetOS() []string {
 	res := []string{runtime.GOOS}
-	if runtime.GOOS == "windows" {
+	switch runtime.GOOS {
+	case "darwin":
+		// Many release assets use macos or osx instead of darwin
+		res = append(res, "macos", "osx")
+	case "windows":
 		// Adding win since some repositories release with that as the indicator of a windows binary
 		res = append(res, "win")
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,35 @@
+package config
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestGetArchIncludesAliases(t *testing.T) {
+	archs := GetArch()
+	contains := func(v string) bool {
+		for _, arch := range archs {
+			if arch == v {
+				return true
+			}
+		}
+		return false
+	}
+
+	if !contains(runtime.GOARCH) {
+		t.Fatalf("expected GetArch to include runtime arch %s, got %v", runtime.GOARCH, archs)
+	}
+
+	if runtime.GOARCH == "amd64" {
+		if !contains("x86_64") {
+			t.Fatalf("expected amd64 aliases to include x86_64, got %v", archs)
+		}
+		if !contains("x64") {
+			t.Fatalf("expected amd64 aliases to include x64, got %v", archs)
+		}
+	}
+
+	if runtime.GOARCH == "arm64" && !contains("aarch64") {
+		t.Fatalf("expected arm64 aliases to include aarch64, got %v", archs)
+	}
+}

--- a/pkg/strings/strings.go
+++ b/pkg/strings/strings.go
@@ -10,3 +10,12 @@ func ContainsAny(s string, v []string) bool {
 	}
 	return false
 }
+
+func HasAnySuffix(s string, suffixes []string) bool {
+	for _, suffix := range suffixes {
+		if strings.HasSuffix(s, suffix) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Improve asset selection accuracy by expanding OS/arch aliases and filtering out non-installable files (checksums/signatures and archive junk) before scoring/selecting release artifacts.

## What changed

- Added arm64 -> aarch64 alias support in GetArch().
- Added Darwin aliases (macos, osx) in GetOS().
- Expanded SanitizeName() normalization to better strip OS/arch/version patterns across common naming permutations.
- Added HasAnySuffix() helper in pkg/strings.
- Introduced installable-asset filtering to skip metadata artifacts (e.g. .sha256, .asc, checksum files).
- Introduced archive-content filtering to skip non-binary files (README/LICENSE/changelog/docs/images/config samples, completion files, manpages) when selecting binaries from .tar/.zip.
- Added safe fallback behavior: if filtering removes everything, keep original candidates.

## Tests

- Added/expanded tests for:
    - arch alias behavior (pkg/config/config_test.go)
    - sanitize-name handling for Darwin ARM naming variants
    - metadata/junk detection helpers
    - archive filtering behavior, including fallback cases
    - manpage extension detection
- Verified with:
    - go test ./... (pass)