### PR TITLE
Print an error when remove doesn't match any binaries

### DIFF
--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -46,7 +46,7 @@ func newRemoveCmd() *removeCmd {
 						// additional things somewhere else, maybe we should
 						// call the provider to do a cleanup here.
 						if err := os.Remove(os.ExpandEnv(bp)); err != nil && !os.IsNotExist(err) {
-							return fmt.Errorf("Error removing path %s: %v", os.ExpandEnv(bp), err)
+							return fmt.Errorf("error removing path %s: %v", os.ExpandEnv(bp), err)
 						}
 						fmt.Fprintf(os.Stderr, "removed binary %s\n", os.ExpandEnv(bp))
 						continue

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -48,6 +48,7 @@ func newRemoveCmd() *removeCmd {
 						if err := os.Remove(os.ExpandEnv(bp)); err != nil && !os.IsNotExist(err) {
 							return fmt.Errorf("Error removing path %s: %v", os.ExpandEnv(bp), err)
 						}
+						fmt.Fprintf(os.Stderr, "removed binary %s\n", os.ExpandEnv(bp))
 						continue
 					}
 				}

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -27,6 +27,7 @@ func newRemoveCmd() *removeCmd {
 			cfg := config.Get()
 
 			existingToRemove := []string{}
+			matched := map[string]bool{}
 
 			for _, b := range cfg.Bins {
 				for _, p := range args {
@@ -39,6 +40,7 @@ func newRemoveCmd() *removeCmd {
 					}
 					if os.ExpandEnv(b.Path) == os.ExpandEnv(bp) || p == b.Path {
 						existingToRemove = append(existingToRemove, b.Path)
+						matched[p] = true
 
 						// TODO some providers (like docker) might download
 						// additional things somewhere else, maybe we should
@@ -50,6 +52,22 @@ func newRemoveCmd() *removeCmd {
 					}
 				}
 			}
+
+			notFound := []string{}
+			for _, p := range args {
+				if !matched[p] {
+					notFound = append(notFound, p)
+				}
+			}
+			if len(notFound) > 0 {
+				for _, p := range notFound {
+					fmt.Fprintf(os.Stderr, "binary %s not found\n", p)
+				}
+				if len(existingToRemove) == 0 {
+					return fmt.Errorf("no matching binaries found")
+				}
+			}
+
 			err := config.RemoveBinaries(existingToRemove)
 			return err
 		},


### PR DESCRIPTION
## Summary

- `bin remove` with arguments that don't match any installed binary previously exited silently with no output. This reports unmatched arguments to stderr and returns an error if nothing was removed.
- If some arguments match and others don't, the matched ones are still removed and the unmatched ones are reported.