### PR TITLE
remove doesn't fail fast if a binary is not found

### DIFF
--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 
 	"github.com/marcosnils/bin/pkg/config"
 	"github.com/spf13/cobra"
@@ -28,26 +29,29 @@ func newRemoveCmd() *removeCmd {
 
 			existingToRemove := []string{}
 
-			for _, b := range cfg.Bins {
-				for _, p := range args {
-					// TODO: avoid calling getBinPath each time and make it
-					// once at the beginning for each arg
-					bp, err := getBinPath(p)
+			bins := cfg.Bins
 
-					if err != nil && !errors.Is(err, os.ErrNotExist) {
-						return err
-					}
-					if os.ExpandEnv(b.Path) == os.ExpandEnv(bp) || p == b.Path {
-						existingToRemove = append(existingToRemove, b.Path)
+			for _, p := range args {
+				// TODO: avoid calling getBinPath each time and make it
+				// once at the beginning for each arg
+				bp, err := getBinPath(p)
 
-						// TODO some providers (like docker) might download
-						// additional things somewhere else, maybe we should
-						// call the provider to do a cleanup here.
-						if err := os.Remove(os.ExpandEnv(bp)); err != nil && !os.IsNotExist(err) {
-							return fmt.Errorf("Error removing path %s: %v", os.ExpandEnv(bp), err)
-						}
-						continue
+				if errors.Is(err, exec.ErrNotFound) || errors.Is(err, os.ErrNotExist) {
+					fmt.Fprintf(os.Stderr, "binary %s not found in PATH, skipping\n", p)
+				} else if err != nil {
+					return err
+				}
+				ebp := os.ExpandEnv(bp)
+				if _, ok := bins[ebp]; ok {
+					existingToRemove = append(existingToRemove, ebp)
+
+					// TODO some providers (like docker) might download
+					// additional things somewhere else, maybe we should
+					// call the provider to do a cleanup here.
+					if err := os.Remove(os.ExpandEnv(bp)); err != nil && !os.IsNotExist(err) {
+						return fmt.Errorf("error removing path %s: %v", os.ExpandEnv(bp), err)
 					}
+					continue
 				}
 			}
 			err := config.RemoveBinaries(existingToRemove)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,7 +28,12 @@ func (cmd *rootCmd) Execute(args []string) {
 	cmd.cmd.SetArgs(args)
 
 	if defaultCommand(cmd.cmd, args) {
-		cmd.cmd.SetArgs(append([]string{"list"}, args...))
+		if len(args) == 0 {
+			cmd.cmd.SetArgs(append([]string{"list"}, args...))
+		} else {
+			fmt.Fprintf(os.Stderr, "unknown command: bin %s\n", args[0])
+			os.Exit(1)
+		}
 	}
 
 	if err := cmd.cmd.Execute(); err != nil {

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ func main() {
 }
 
 func buildVersion(version, commit, date, builtBy string) string {
-	var result = version
+	result := version
 	if commit != "" {
 		result = fmt.Sprintf("%s\ncommit: %s", result, commit)
 	}


### PR DESCRIPTION
- also removing `ls` as being the default command as it's confusing

fixes #276

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
