### PR TITLE
honour HTTP_PROXY/HTTPS_PROXY/NO_PROXY in all HTTP clients

### DIFF
--- a/pkg/assets/assets.go
+++ b/pkg/assets/assets.go
@@ -20,6 +20,7 @@ import (
 	"github.com/h2non/filetype/types"
 	"github.com/krolaw/zipstream"
 	"github.com/marcosnils/bin/pkg/config"
+	"github.com/marcosnils/bin/pkg/httpclient"
 	"github.com/marcosnils/bin/pkg/options"
 	bstrings "github.com/marcosnils/bin/pkg/strings"
 	"github.com/xi2/xz"
@@ -345,7 +346,7 @@ func (f *Filter) ProcessURL(gf *FilteredAsset) (*finalFile, error) {
 		req.Header.Add(name, value)
 	}
 	log.Debugf("Checking binary from %s", gf.URL)
-	res, err := http.DefaultClient.Do(req)
+	res, err := httpclient.Client.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/httpclient/client.go
+++ b/pkg/httpclient/client.go
@@ -1,0 +1,7 @@
+package httpclient
+
+import "net/http"
+
+// Client is a shared *http.Client backed by http.DefaultTransport, which reads
+// HTTP_PROXY, HTTPS_PROXY, and NO_PROXY from the environment.
+var Client = &http.Client{Transport: http.DefaultTransport}

--- a/pkg/providers/github.go
+++ b/pkg/providers/github.go
@@ -12,6 +12,7 @@ import (
 	"github.com/caarlos0/log"
 	"github.com/google/go-github/v31/github"
 	"github.com/marcosnils/bin/pkg/assets"
+	"github.com/marcosnils/bin/pkg/httpclient"
 	"golang.org/x/oauth2"
 )
 
@@ -177,14 +178,16 @@ func newGitHub(u *url.URL) (Provider, error) {
 	guu := os.Getenv("GHES_UPLOAD_URL")
 	gau := os.Getenv("GHES_AUTH_TOKEN")
 
+	oauthCtx := context.WithValue(context.Background(), oauth2.HTTPClient, httpclient.Client)
+
 	var tc *http.Client
 
 	if len(gbu) > 0 && len(guu) > 0 && len(gau) > 0 {
-		tc = oauth2.NewClient(context.Background(), oauth2.StaticTokenSource(
+		tc = oauth2.NewClient(oauthCtx, oauth2.StaticTokenSource(
 			&oauth2.Token{AccessToken: gau},
 		))
 	} else if token != "" {
-		tc = oauth2.NewClient(context.Background(), oauth2.StaticTokenSource(
+		tc = oauth2.NewClient(oauthCtx, oauth2.StaticTokenSource(
 			&oauth2.Token{AccessToken: token},
 		))
 	}

--- a/pkg/providers/goinstall.go
+++ b/pkg/providers/goinstall.go
@@ -4,13 +4,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 
 	"github.com/caarlos0/log"
+	"github.com/marcosnils/bin/pkg/httpclient"
 )
 
 type goinstall struct {
@@ -97,7 +97,7 @@ func (g *goinstall) Fetch(opts *FetchOpts) (*File, error) {
 }
 
 func (g *goinstall) GetLatestVersion() (string, string, error) {
-	resp, err := http.Get(g.latestURL)
+	resp, err := httpclient.Client.Get(g.latestURL)
 	if err != nil {
 		return "", "", err
 	}

--- a/pkg/providers/hashicorp.go
+++ b/pkg/providers/hashicorp.go
@@ -12,6 +12,7 @@ import (
 	"github.com/caarlos0/log"
 	"github.com/coreos/go-semver/semver"
 	"github.com/marcosnils/bin/pkg/assets"
+	"github.com/marcosnils/bin/pkg/httpclient"
 	"github.com/marcosnils/bin/pkg/options"
 )
 
@@ -194,5 +195,5 @@ func newHashiCorp(u *url.URL) (Provider, error) {
 
 	baseURL, _ := url.Parse(releasesURLBase)
 
-	return &hashiCorp{url: u, client: http.DefaultClient, owner: "", repo: s[1], tag: tag, baseURL: baseURL}, nil
+	return &hashiCorp{url: u, client: httpclient.Client, owner: "", repo: s[1], tag: tag, baseURL: baseURL}, nil
 }


### PR DESCRIPTION
## Summary

Fixes #287 — `bin` was not honouring standard proxy environment variables (`HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`), making it unusable in corporate/air-gapped environments.

- Introduces `pkg/httpclient` with a shared `*http.Client` backed by `http.DefaultTransport` (which calls `http.ProxyFromEnvironment`)
- `pkg/assets/assets.go` — uses `httpclient.Client` instead of `http.DefaultClient`
- `pkg/providers/goinstall.go` — uses `httpclient.Client.Get` instead of `http.Get`
- `pkg/providers/hashicorp.go` — passes `httpclient.Client` instead of `http.DefaultClient`
- `pkg/providers/github.go` — injects `httpclient.Client` via `oauth2.HTTPClient` context key so the oauth2 transport uses a proxy-aware base

## Test plan

- [x] Set `HTTPS_PROXY` to a local proxy (e.g. `mitmproxy`) and run `bin install` for a GitHub, HashiCorp, and `goinstall://` binary — all requests should route through the proxy
- [x] Unset proxy vars and verify normal operation is unchanged
- [x] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)