### PR TITLE
feat: add helm provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ While this makes distribution easier, it creates challenges for updates and trac
   - [Codeberg Releases](#codeberg-releases)
   - [Docker Images](#docker-images)
   - [Hashicorp Releases](#hashicorp-releases)
+  - [Helm](#helm)
   - [Go Install](#go-install)
 
 For a comprehensive list, see the [Tools Wiki](https://github.com/marcosnils/bin/wiki/Tools-list).
@@ -201,6 +202,35 @@ If you need multiple versions, specify a destination
 ```shell
 bin install --provider hashicorp https://releases.hashicorp.com/terraform/1.5.7 ~/bin/terraform-1.5.7
 bin install --provider hashicorp https://releases.hashicorp.com/terraform/1.12.1 ~/bin/terraform-1.12.1
+```
+
+### Helm
+
+#### Configuration
+
+None.
+
+#### Usage
+
+[Helm](https://helm.sh) does not attach binaries to its GitHub releases (only
+signatures and checksums) and instead distributes them from
+[get.helm.sh](https://get.helm.sh), so it needs a dedicated provider. `bin`
+detects `github.com/helm/helm` automatically and installs the latest version.
+
+```shell
+bin install github.com/helm/helm
+```
+
+You can also target `get.helm.sh` directly or force the provider:
+
+```shell
+bin install --provider helm github.com/helm/helm
+```
+
+To install a specific version, use a release tag URL:
+
+```shell
+bin install github.com/helm/helm/releases/tag/v3.16.3 ~/bin/helm-3.16.3
 ```
 
 ### Go Install

--- a/README.md
+++ b/README.md
@@ -221,12 +221,12 @@ selected automatically for that host.
 bin install get.helm.sh
 ```
 
-To install a specific version, append it to the URL or use a release
-download URL (the binary matching your platform is selected either way):
+To install a specific version, use the full release download URL (the
+binary matching your platform is selected regardless of the one in the
+URL):
 
 ```shell
-bin install get.helm.sh/v3.16.3 ~/bin/helm-3.16.3
-bin install https://get.helm.sh/helm-v3.16.3-linux-amd64.tar.gz
+bin install https://get.helm.sh/helm-v3.16.3-linux-amd64.tar.gz ~/bin/helm-3.16.3
 ```
 
 ### Go Install

--- a/README.md
+++ b/README.md
@@ -214,23 +214,19 @@ None.
 
 [Helm](https://helm.sh) does not attach binaries to its GitHub releases (only
 signatures and checksums) and instead distributes them from
-[get.helm.sh](https://get.helm.sh), so it needs a dedicated provider. `bin`
-detects `github.com/helm/helm` automatically and installs the latest version.
+[get.helm.sh](https://get.helm.sh), so it needs a dedicated provider that is
+selected automatically for that host.
 
 ```shell
-bin install github.com/helm/helm
+bin install get.helm.sh
 ```
 
-You can also target `get.helm.sh` directly or force the provider:
+To install a specific version, append it to the URL or use a release
+download URL (the binary matching your platform is selected either way):
 
 ```shell
-bin install --provider helm github.com/helm/helm
-```
-
-To install a specific version, use a release tag URL:
-
-```shell
-bin install github.com/helm/helm/releases/tag/v3.16.3 ~/bin/helm-3.16.3
+bin install get.helm.sh/v3.16.3 ~/bin/helm-3.16.3
+bin install https://get.helm.sh/helm-v3.16.3-linux-amd64.tar.gz
 ```
 
 ### Go Install

--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ While this makes distribution easier, it creates challenges for updates and trac
   - [Gitlab Releases](#gitlab-releases)
   - [Codeberg Releases](#codeberg-releases)
   - [Docker Images](#docker-images)
-  - [Hashicorp Releases](#hashicorp-releases)
-  - [Helm](#helm)
+  - [HTTP Releases (Hashicorp, Helm)](#http-releases)
   - [Go Install](#go-install)
 
 For a comprehensive list, see the [Tools Wiki](https://github.com/marcosnils/bin/wiki/Tools-list).
@@ -183,7 +182,7 @@ export DOCKER_HOST="unix:///path/to/unix/socket"
 bin install docker://quay.io/calico/node
 ```
 
-### Hashicorp Releases
+### HTTP Releases
 
 #### Configuration
 
@@ -191,41 +190,23 @@ None.
 
 #### Usage
 
-Hashicorp have a [dedicated releases](https://releases.hashicorp.com) page and don't use github/lab releases, `bin` support it.
+Some projects distribute their binaries from a plain HTTP download page
+instead of GitHub-style release assets. `bin` supports these through
+dedicated HTTP providers, selected automatically by host:
+
+- [releases.hashicorp.com](https://releases.hashicorp.com) (Terraform, Vault, ...)
+- [get.helm.sh](https://get.helm.sh) (Helm)
 
 ```shell
-bin install --provider hashicorp https://releases.hashicorp.com/terraform/1.12.1
-```
-
-If you need multiple versions, specify a destination
-
-```shell
-bin install --provider hashicorp https://releases.hashicorp.com/terraform/1.5.7 ~/bin/terraform-1.5.7
-bin install --provider hashicorp https://releases.hashicorp.com/terraform/1.12.1 ~/bin/terraform-1.12.1
-```
-
-### Helm
-
-#### Configuration
-
-None.
-
-#### Usage
-
-[Helm](https://helm.sh) does not attach binaries to its GitHub releases (only
-signatures and checksums) and instead distributes them from
-[get.helm.sh](https://get.helm.sh), so it needs a dedicated provider that is
-selected automatically for that host.
-
-```shell
+bin install releases.hashicorp.com/terraform
 bin install get.helm.sh
 ```
 
-To install a specific version, use the full release download URL (the
-binary matching your platform is selected regardless of the one in the
-URL):
+To install a specific version, use the versioned URL (the binary matching
+your platform is selected automatically):
 
 ```shell
+bin install https://releases.hashicorp.com/terraform/1.5.7 ~/bin/terraform-1.5.7
 bin install https://get.helm.sh/helm-v3.16.3-linux-amd64.tar.gz ~/bin/helm-3.16.3
 ```
 

--- a/pkg/providers/hashicorp.go
+++ b/pkg/providers/hashicorp.go
@@ -21,11 +21,8 @@ const (
 )
 
 type hashiCorp struct {
-	url     *url.URL
 	client  *http.Client
-	owner   string
 	repo    string
-	tag     string
 	baseURL *url.URL
 }
 
@@ -67,72 +64,15 @@ func (g *hashiCorp) listReleases(repoName string) (*hashiCorpRepo, error) {
 	return &repo, nil
 }
 
-func (g *hashiCorp) GetID() string {
-	return "hashicorp"
-}
-
-func (g *hashiCorp) Fetch(opts *FetchOpts) (*File, error) {
-	var release *hashiCorpRelease
-
-	// If we have a tag, let's fetch from there
-	var err error
-	if len(g.tag) > 0 || len(opts.Version) > 0 {
-		if len(opts.Version) > 0 {
-			// this is used by for the `ensure` command
-			g.tag = opts.Version
-		}
-		log.Infof("Getting %s release for %s", g.tag, g.repo)
-		release, err = g.getRelease(g.repo, g.tag)
-	} else {
-		var version string
-		version, _, err = g.GetLatestVersion()
-		if err != nil {
-			return nil, err
-		}
-		release, err = g.getRelease(g.repo, version)
-	}
-
-	if err != nil {
-		return nil, err
-	}
-
-	candidates := []*assets.Asset{}
-	for _, link := range release.Builds {
-		candidates = append(candidates, &assets.Asset{Name: link.Filename, URL: link.URL})
-	}
-
-	f := assets.NewFilter(&assets.FilterOpts{SkipScoring: opts.All, PackagePath: opts.PackagePath, SkipPathCheck: opts.SkipPatchCheck, NamePattern: opts.NamePattern})
-	gf, err := f.FilterAssets(g.repo, candidates)
-	if err != nil {
-		return nil, err
-	}
-
-	outFile, err := f.ProcessURL(gf)
-	if err != nil {
-		return nil, err
-	}
-
-	version := release.Version
-
-	// TODO calculate file hash. Not sure if we can / should do it here
-	// since we don't want to read the file unnecessarily. Additionally, sometimes
-	// releases have .sha256 files, so it'd be nice to check for those also
-	file := &File{Data: outFile.Source, Name: outFile.Name, Version: version}
-
-	return file, nil
-}
-
-// GetLatestVersion checks the latest repo release and
-// returns the corresponding name and url to fetch the version
-func (g *hashiCorp) GetLatestVersion() (string, string, error) {
-	log.Debugf("Getting latest release for %s", g.repo)
-
+// latestRelease finds the highest non-prerelease semver version, asking the
+// user to disambiguate ties, and fetches its release metadata.
+func (g *hashiCorp) latestRelease() (*hashiCorpRelease, error) {
 	releases, err := g.listReleases(g.repo)
 	if err != nil {
-		return "", "", err
+		return nil, err
 	}
 	if len(releases.Versions) == 0 {
-		return "", "", fmt.Errorf("no releases found for %s", g.repo)
+		return nil, fmt.Errorf("no releases found for %s", g.repo)
 	}
 	var svs semver.Versions
 	for _, version := range releases.Versions {
@@ -146,7 +86,7 @@ func (g *hashiCorp) GetLatestVersion() (string, string, error) {
 		}
 	}
 	if len(svs) == 0 {
-		return "", "", fmt.Errorf("no semver versions found for %s", g.repo)
+		return nil, fmt.Errorf("no semver versions found for %s", g.repo)
 	}
 	sort.Sort(svs)
 	highestVersion := svs[len(svs)-1]
@@ -169,11 +109,39 @@ func (g *hashiCorp) GetLatestVersion() (string, string, error) {
 		}
 		choice, err := options.Select("Select file to download:", generic)
 		if err != nil {
-			return "", "", err
+			return nil, err
 		}
 		highestVersion = choice.(*semver.Version)
 	}
-	release, err := g.getRelease(g.repo, highestVersion.String())
+	return g.getRelease(g.repo, highestVersion.String())
+}
+
+func (g *hashiCorp) fetchRelease(version string) (string, []*assets.Asset, error) {
+	var release *hashiCorpRelease
+	var err error
+	if version == "" {
+		release, err = g.latestRelease()
+	} else {
+		release, err = g.getRelease(g.repo, version)
+	}
+	if err != nil {
+		return "", nil, err
+	}
+
+	candidates := make([]*assets.Asset, 0, len(release.Builds))
+	for _, link := range release.Builds {
+		candidates = append(candidates, &assets.Asset{Name: link.Filename, URL: link.URL})
+	}
+
+	return release.Version, candidates, nil
+}
+
+// latestVersion checks the latest repo release and
+// returns the corresponding name and url to fetch the version
+func (g *hashiCorp) latestVersion() (string, string, error) {
+	log.Debugf("Getting latest release for %s", g.repo)
+
+	release, err := g.latestRelease()
 	if err != nil {
 		return "", "", err
 	}
@@ -183,7 +151,7 @@ func (g *hashiCorp) GetLatestVersion() (string, string, error) {
 
 func newHashiCorp(u *url.URL) (Provider, error) {
 	s := strings.Split(u.Path, "/")
-	if len(s) < 1 {
+	if len(s) < 2 {
 		return nil, fmt.Errorf("Error parsing HashiCorp releases URL %s, can't find repo", u.String())
 	}
 
@@ -195,5 +163,6 @@ func newHashiCorp(u *url.URL) (Provider, error) {
 
 	baseURL, _ := url.Parse(releasesURLBase)
 
-	return &hashiCorp{url: u, client: httpclient.Client, owner: "", repo: s[1], tag: tag, baseURL: baseURL}, nil
+	src := &hashiCorp{client: httpclient.Client, repo: s[1], baseURL: baseURL}
+	return &httpReleaseProvider{id: "hashicorp", name: src.repo, tag: tag, src: src}, nil
 }

--- a/pkg/providers/hashicorp.go
+++ b/pkg/providers/hashicorp.go
@@ -164,5 +164,5 @@ func newHashiCorp(u *url.URL) (Provider, error) {
 	baseURL, _ := url.Parse(releasesURLBase)
 
 	src := &hashiCorp{client: httpclient.Client, repo: s[1], baseURL: baseURL}
-	return &httpReleaseProvider{id: "hashicorp", name: src.repo, tag: tag, src: src}, nil
+	return &httpReleaseProvider{id: "hashicorp", tag: tag, src: src}, nil
 }

--- a/pkg/providers/hashicorp_test.go
+++ b/pkg/providers/hashicorp_test.go
@@ -125,9 +125,6 @@ func TestHashiCorpProviderURLRoundTrip(t *testing.T) {
 	if !ok || hp.GetID() != "hashicorp" {
 		t.Fatalf("got %T (%s), want hashicorp httpReleaseProvider", p, p.GetID())
 	}
-	if hp.name != "terraform" {
-		t.Errorf("name = %q, want terraform", hp.name)
-	}
 	if hp.tag != "1.5.7" {
 		t.Errorf("tag = %q, want 1.5.7", hp.tag)
 	}

--- a/pkg/providers/hashicorp_test.go
+++ b/pkg/providers/hashicorp_test.go
@@ -1,0 +1,134 @@
+package providers
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+// newTestHashiCorp returns a hashiCorp source backed by an httptest server
+// serving the given index.json payloads keyed by request path.
+func newTestHashiCorp(t *testing.T, responses map[string]string) *hashiCorp {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, ok := responses[r.URL.Path]
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		fmt.Fprint(w, body)
+	}))
+	t.Cleanup(srv.Close)
+
+	baseURL, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &hashiCorp{client: srv.Client(), repo: "terraform", baseURL: baseURL}
+}
+
+const terraformRepoIndex = `{
+	"name": "terraform",
+	"versions": {
+		"1.5.0": {"name": "terraform", "version": "1.5.0"},
+		"1.5.7": {"name": "terraform", "version": "1.5.7"},
+		"1.6.0-beta1": {"name": "terraform", "version": "1.6.0-beta1"}
+	}
+}`
+
+const terraformRelease157 = `{
+	"name": "terraform",
+	"version": "1.5.7",
+	"builds": [
+		{"os": "linux", "arch": "amd64", "filename": "terraform_1.5.7_linux_amd64.zip", "url": "https://releases.hashicorp.com/terraform/1.5.7/terraform_1.5.7_linux_amd64.zip"},
+		{"os": "darwin", "arch": "arm64", "filename": "terraform_1.5.7_darwin_arm64.zip", "url": "https://releases.hashicorp.com/terraform/1.5.7/terraform_1.5.7_darwin_arm64.zip"}
+	]
+}`
+
+const terraformRelease150 = `{
+	"name": "terraform",
+	"version": "1.5.0",
+	"builds": [
+		{"os": "linux", "arch": "amd64", "filename": "terraform_1.5.0_linux_amd64.zip", "url": "https://releases.hashicorp.com/terraform/1.5.0/terraform_1.5.0_linux_amd64.zip"}
+	]
+}`
+
+func TestHashiCorpFetchReleaseLatest(t *testing.T) {
+	// prereleases (1.6.0-beta1) must be skipped when picking the latest
+	g := newTestHashiCorp(t, map[string]string{
+		"/terraform/index.json":       terraformRepoIndex,
+		"/terraform/1.5.7/index.json": terraformRelease157,
+	})
+
+	version, candidates, err := g.fetchRelease("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if version != "1.5.7" {
+		t.Errorf("version = %q, want 1.5.7", version)
+	}
+	if len(candidates) != 2 {
+		t.Fatalf("got %d candidates, want 2", len(candidates))
+	}
+	if candidates[0].Name != "terraform_1.5.7_linux_amd64.zip" {
+		t.Errorf("candidate name = %q, want terraform_1.5.7_linux_amd64.zip", candidates[0].Name)
+	}
+}
+
+func TestHashiCorpFetchReleaseSpecificVersion(t *testing.T) {
+	g := newTestHashiCorp(t, map[string]string{
+		"/terraform/1.5.0/index.json": terraformRelease150,
+	})
+
+	version, candidates, err := g.fetchRelease("1.5.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if version != "1.5.0" {
+		t.Errorf("version = %q, want 1.5.0", version)
+	}
+	if len(candidates) != 1 {
+		t.Fatalf("got %d candidates, want 1", len(candidates))
+	}
+}
+
+func TestHashiCorpLatestVersionURL(t *testing.T) {
+	g := newTestHashiCorp(t, map[string]string{
+		"/terraform/index.json":       terraformRepoIndex,
+		"/terraform/1.5.7/index.json": terraformRelease157,
+	})
+
+	version, versionURL, err := g.latestVersion()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if version != "1.5.7" {
+		t.Errorf("version = %q, want 1.5.7", version)
+	}
+	want := g.baseURL.String() + "/terraform/1.5.7/index.json"
+	if versionURL != want {
+		t.Errorf("url = %q, want %q", versionURL, want)
+	}
+}
+
+// TestHashiCorpProviderURLRoundTrip ensures the URL shape returned by
+// latestVersion resolves back to the hashicorp provider with the same tag,
+// since the update command re-instantiates providers from that URL.
+func TestHashiCorpProviderURLRoundTrip(t *testing.T) {
+	p, err := New("https://releases.hashicorp.com/terraform/1.5.7/index.json", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	hp, ok := p.(*httpReleaseProvider)
+	if !ok || hp.GetID() != "hashicorp" {
+		t.Fatalf("got %T (%s), want hashicorp httpReleaseProvider", p, p.GetID())
+	}
+	if hp.name != "terraform" {
+		t.Errorf("name = %q, want terraform", hp.name)
+	}
+	if hp.tag != "1.5.7" {
+		t.Errorf("tag = %q, want 1.5.7", hp.tag)
+	}
+}

--- a/pkg/providers/helm.go
+++ b/pkg/providers/helm.go
@@ -1,0 +1,157 @@
+package providers
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/caarlos0/log"
+	"github.com/marcosnils/bin/pkg/assets"
+	"github.com/marcosnils/bin/pkg/httpclient"
+)
+
+const (
+	helmDownloadBase  = "https://get.helm.sh"
+	helmLatestVersion = "https://get.helm.sh/helm-latest-version"
+	helmReleasesURL   = "https://github.com/helm/helm/releases/tag"
+)
+
+// helmPlatform is a single os/arch combination published on get.helm.sh.
+type helmPlatform struct {
+	os   string
+	arch string
+	ext  string
+}
+
+// helmPlatforms enumerates the binaries Helm publishes for every release.
+// Helm does not attach binaries to its GitHub releases (only signatures and
+// checksums) and get.helm.sh has no listing API, so bin builds this static
+// candidate list and scores it the same way it scores assets from the other
+// providers to pick the one matching the running platform.
+var helmPlatforms = []helmPlatform{
+	{"darwin", "amd64", "tar.gz"},
+	{"darwin", "arm64", "tar.gz"},
+	{"linux", "386", "tar.gz"},
+	{"linux", "amd64", "tar.gz"},
+	{"linux", "arm", "tar.gz"},
+	{"linux", "arm64", "tar.gz"},
+	{"linux", "loong64", "tar.gz"},
+	{"linux", "ppc64le", "tar.gz"},
+	{"linux", "riscv64", "tar.gz"},
+	{"linux", "s390x", "tar.gz"},
+	{"windows", "amd64", "zip"},
+	{"windows", "arm64", "zip"},
+}
+
+type helm struct {
+	url    *url.URL
+	client *http.Client
+	repo   string
+	tag    string
+}
+
+func (h *helm) GetID() string {
+	return "helm"
+}
+
+// candidates builds the list of downloadable assets for a given version.
+func (h *helm) candidates(version string) []*assets.Asset {
+	cs := make([]*assets.Asset, 0, len(helmPlatforms))
+	for _, p := range helmPlatforms {
+		name := fmt.Sprintf("helm-%s-%s-%s.%s", version, p.os, p.arch, p.ext)
+		cs = append(cs, &assets.Asset{
+			Name: name,
+			URL:  fmt.Sprintf("%s/%s", helmDownloadBase, name),
+		})
+	}
+	return cs
+}
+
+func (h *helm) Fetch(opts *FetchOpts) (*File, error) {
+	version := h.tag
+	if len(opts.Version) > 0 {
+		// this is used by the `ensure` command
+		version = opts.Version
+	}
+
+	if version == "" {
+		var err error
+		version, _, err = h.GetLatestVersion()
+		if err != nil {
+			return nil, err
+		}
+	}
+	version = normalizeHelmVersion(version)
+
+	log.Infof("Getting %s release for %s", version, h.repo)
+
+	f := assets.NewFilter(&assets.FilterOpts{SkipScoring: opts.All, PackagePath: opts.PackagePath, SkipPathCheck: opts.SkipPatchCheck, PackageName: opts.PackageName, NamePattern: opts.NamePattern})
+
+	gf, err := f.FilterAssets(h.repo, h.candidates(version))
+	if err != nil {
+		return nil, err
+	}
+
+	// The Helm archives contain an os-arch/ directory (e.g. linux-amd64/helm),
+	// which ProcessURL unpacks, keeping the executable file.
+	outFile, err := f.ProcessURL(gf)
+	if err != nil {
+		return nil, err
+	}
+
+	return &File{Data: outFile.Source, Name: outFile.Name, Version: version, PackagePath: outFile.PackagePath}, nil
+}
+
+// GetLatestVersion returns the latest Helm version and a URL to its release notes.
+func (h *helm) GetLatestVersion() (string, string, error) {
+	log.Debugf("Getting latest release for %s", h.repo)
+
+	resp, err := h.client.Get(helmLatestVersion)
+	if err != nil {
+		return "", "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", "", fmt.Errorf("%d response getting latest Helm version from %s", resp.StatusCode, helmLatestVersion)
+	}
+
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", "", err
+	}
+
+	version := normalizeHelmVersion(strings.TrimSpace(string(b)))
+	if version == "" {
+		return "", "", fmt.Errorf("could not determine latest Helm version")
+	}
+
+	return version, fmt.Sprintf("%s/%s", helmReleasesURL, version), nil
+}
+
+// normalizeHelmVersion ensures the version carries the leading "v" that Helm's
+// release tags and download filenames use (e.g. v3.16.3).
+func normalizeHelmVersion(version string) string {
+	if version == "" || strings.HasPrefix(version, "v") {
+		return version
+	}
+	return "v" + version
+}
+
+func newHelm(u *url.URL) (Provider, error) {
+	// Support explicit release URLs such as
+	// github.com/helm/helm/releases/tag/v3.16.3
+	var tag string
+	if strings.Contains(u.Path, "/releases/") {
+		ps := strings.Split(u.Path, "/")
+		for i, p := range ps {
+			if p == "releases" && i+2 < len(ps) {
+				tag = strings.Join(ps[i+2:], "/")
+			}
+		}
+	}
+
+	return &helm{url: u, client: httpclient.Client, repo: "helm", tag: tag}, nil
+}

--- a/pkg/providers/helm.go
+++ b/pkg/providers/helm.go
@@ -15,7 +15,6 @@ import (
 const (
 	helmDownloadBase  = "https://get.helm.sh"
 	helmLatestVersion = "https://get.helm.sh/helm-latest-version"
-	helmReleasesURL   = "https://github.com/helm/helm/releases/tag"
 )
 
 // helmPlatform is a single os/arch combination published on get.helm.sh.
@@ -101,7 +100,7 @@ func (h *helm) latestVersion() (string, string, error) {
 		return "", "", fmt.Errorf("could not determine latest Helm version")
 	}
 
-	return version, fmt.Sprintf("%s/%s", helmReleasesURL, version), nil
+	return version, fmt.Sprintf("%s/%s", helmDownloadBase, version), nil
 }
 
 // normalizeHelmVersion ensures the version carries the leading "v" that Helm's
@@ -113,15 +112,21 @@ func normalizeHelmVersion(version string) string {
 	return "v" + version
 }
 
-// parseHelmTag extracts the version from explicit release URLs such as
-// github.com/helm/helm/releases/tag/v3.16.3.
+// parseHelmTag extracts the version from get.helm.sh URLs, either a bare
+// version path (get.helm.sh/v3.16.3) or a release download URL
+// (get.helm.sh/helm-v3.16.3-linux-amd64.tar.gz).
 func parseHelmTag(u *url.URL) string {
-	var tag string
-	if strings.Contains(u.Path, "/releases/") {
-		ps := strings.Split(u.Path, "/")
-		for i, p := range ps {
-			if p == "releases" && i+2 < len(ps) {
-				tag = strings.Join(ps[i+2:], "/")
+	tag := strings.Trim(u.Path, "/")
+	if tag == "" || tag == "helm-latest-version" {
+		return ""
+	}
+	if strings.HasPrefix(tag, "helm-") {
+		tag = strings.TrimPrefix(tag, "helm-")
+		for _, p := range helmPlatforms {
+			suffix := fmt.Sprintf("-%s-%s.%s", p.os, p.arch, p.ext)
+			if strings.HasSuffix(tag, suffix) {
+				tag = strings.TrimSuffix(tag, suffix)
+				break
 			}
 		}
 	}

--- a/pkg/providers/helm.go
+++ b/pkg/providers/helm.go
@@ -130,9 +130,8 @@ func parseHelmTag(u *url.URL) string {
 
 func newHelm(u *url.URL) (Provider, error) {
 	return &httpReleaseProvider{
-		id:   "helm",
-		name: "helm",
-		tag:  parseHelmTag(u),
-		src:  &helm{client: httpclient.Client},
+		id:  "helm",
+		tag: parseHelmTag(u),
+		src: &helm{client: httpclient.Client},
 	}, nil
 }

--- a/pkg/providers/helm.go
+++ b/pkg/providers/helm.go
@@ -46,14 +46,7 @@ var helmPlatforms = []helmPlatform{
 }
 
 type helm struct {
-	url    *url.URL
 	client *http.Client
-	repo   string
-	tag    string
-}
-
-func (h *helm) GetID() string {
-	return "helm"
 }
 
 // candidates builds the list of downloadable assets for a given version.
@@ -69,44 +62,24 @@ func (h *helm) candidates(version string) []*assets.Asset {
 	return cs
 }
 
-func (h *helm) Fetch(opts *FetchOpts) (*File, error) {
-	version := h.tag
-	if len(opts.Version) > 0 {
-		// this is used by the `ensure` command
-		version = opts.Version
-	}
-
+func (h *helm) fetchRelease(version string) (string, []*assets.Asset, error) {
+	version = normalizeHelmVersion(version)
 	if version == "" {
 		var err error
-		version, _, err = h.GetLatestVersion()
+		version, _, err = h.latestVersion()
 		if err != nil {
-			return nil, err
+			return "", nil, err
 		}
-	}
-	version = normalizeHelmVersion(version)
-
-	log.Infof("Getting %s release for %s", version, h.repo)
-
-	f := assets.NewFilter(&assets.FilterOpts{SkipScoring: opts.All, PackagePath: opts.PackagePath, SkipPathCheck: opts.SkipPatchCheck, PackageName: opts.PackageName, NamePattern: opts.NamePattern})
-
-	gf, err := f.FilterAssets(h.repo, h.candidates(version))
-	if err != nil {
-		return nil, err
 	}
 
 	// The Helm archives contain an os-arch/ directory (e.g. linux-amd64/helm),
 	// which ProcessURL unpacks, keeping the executable file.
-	outFile, err := f.ProcessURL(gf)
-	if err != nil {
-		return nil, err
-	}
-
-	return &File{Data: outFile.Source, Name: outFile.Name, Version: version, PackagePath: outFile.PackagePath}, nil
+	return version, h.candidates(version), nil
 }
 
-// GetLatestVersion returns the latest Helm version and a URL to its release notes.
-func (h *helm) GetLatestVersion() (string, string, error) {
-	log.Debugf("Getting latest release for %s", h.repo)
+// latestVersion returns the latest Helm version and a URL to its release notes.
+func (h *helm) latestVersion() (string, string, error) {
+	log.Debugf("Getting latest release for helm")
 
 	resp, err := h.client.Get(helmLatestVersion)
 	if err != nil {
@@ -140,9 +113,9 @@ func normalizeHelmVersion(version string) string {
 	return "v" + version
 }
 
-func newHelm(u *url.URL) (Provider, error) {
-	// Support explicit release URLs such as
-	// github.com/helm/helm/releases/tag/v3.16.3
+// parseHelmTag extracts the version from explicit release URLs such as
+// github.com/helm/helm/releases/tag/v3.16.3.
+func parseHelmTag(u *url.URL) string {
 	var tag string
 	if strings.Contains(u.Path, "/releases/") {
 		ps := strings.Split(u.Path, "/")
@@ -152,6 +125,14 @@ func newHelm(u *url.URL) (Provider, error) {
 			}
 		}
 	}
+	return normalizeHelmVersion(tag)
+}
 
-	return &helm{url: u, client: httpclient.Client, repo: "helm", tag: tag}, nil
+func newHelm(u *url.URL) (Provider, error) {
+	return &httpReleaseProvider{
+		id:   "helm",
+		name: "helm",
+		tag:  parseHelmTag(u),
+		src:  &helm{client: httpclient.Client},
+	}, nil
 }

--- a/pkg/providers/helm.go
+++ b/pkg/providers/helm.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"runtime"
 	"strings"
 
 	"github.com/caarlos0/log"
@@ -48,17 +49,36 @@ type helm struct {
 	client *http.Client
 }
 
+// downloadName builds the release archive filename for a version and platform.
+func (p helmPlatform) downloadName(version string) string {
+	return fmt.Sprintf("helm-%s-%s-%s.%s", version, p.os, p.arch, p.ext)
+}
+
 // candidates builds the list of downloadable assets for a given version.
 func (h *helm) candidates(version string) []*assets.Asset {
 	cs := make([]*assets.Asset, 0, len(helmPlatforms))
 	for _, p := range helmPlatforms {
-		name := fmt.Sprintf("helm-%s-%s-%s.%s", version, p.os, p.arch, p.ext)
+		name := p.downloadName(version)
 		cs = append(cs, &assets.Asset{
 			Name: name,
 			URL:  fmt.Sprintf("%s/%s", helmDownloadBase, name),
 		})
 	}
 	return cs
+}
+
+// downloadURL returns the release download URL for the running platform,
+// falling back to linux/amd64. It is the URL shape latestVersion hands back
+// for updates, which re-resolve the platform when installing anyway.
+func helmDownloadURL(version string) string {
+	platform := helmPlatforms[3] // linux/amd64
+	for _, p := range helmPlatforms {
+		if p.os == runtime.GOOS && p.arch == runtime.GOARCH {
+			platform = p
+			break
+		}
+	}
+	return fmt.Sprintf("%s/%s", helmDownloadBase, platform.downloadName(version))
 }
 
 func (h *helm) fetchRelease(version string) (string, []*assets.Asset, error) {
@@ -76,7 +96,7 @@ func (h *helm) fetchRelease(version string) (string, []*assets.Asset, error) {
 	return version, h.candidates(version), nil
 }
 
-// latestVersion returns the latest Helm version and a URL to its release notes.
+// latestVersion returns the latest Helm version and its download URL.
 func (h *helm) latestVersion() (string, string, error) {
 	log.Debugf("Getting latest release for helm")
 
@@ -100,7 +120,7 @@ func (h *helm) latestVersion() (string, string, error) {
 		return "", "", fmt.Errorf("could not determine latest Helm version")
 	}
 
-	return version, fmt.Sprintf("%s/%s", helmDownloadBase, version), nil
+	return version, helmDownloadURL(version), nil
 }
 
 // normalizeHelmVersion ensures the version carries the leading "v" that Helm's
@@ -112,31 +132,33 @@ func normalizeHelmVersion(version string) string {
 	return "v" + version
 }
 
-// parseHelmTag extracts the version from get.helm.sh URLs, either a bare
-// version path (get.helm.sh/v3.16.3) or a release download URL
-// (get.helm.sh/helm-v3.16.3-linux-amd64.tar.gz).
-func parseHelmTag(u *url.URL) string {
+// parseHelmTag extracts the pinned version from a release download URL such
+// as get.helm.sh/helm-v3.16.3-linux-amd64.tar.gz. get.helm.sh serves no
+// other installable URLs, so any other non-empty path is rejected.
+func parseHelmTag(u *url.URL) (string, error) {
 	tag := strings.Trim(u.Path, "/")
-	if tag == "" || tag == "helm-latest-version" {
-		return ""
+	if tag == "" {
+		return "", nil
 	}
-	if strings.HasPrefix(tag, "helm-") {
-		tag = strings.TrimPrefix(tag, "helm-")
+	if v, ok := strings.CutPrefix(tag, "helm-"); ok {
 		for _, p := range helmPlatforms {
 			suffix := fmt.Sprintf("-%s-%s.%s", p.os, p.arch, p.ext)
-			if strings.HasSuffix(tag, suffix) {
-				tag = strings.TrimSuffix(tag, suffix)
-				break
+			if strings.HasSuffix(v, suffix) {
+				return normalizeHelmVersion(strings.TrimSuffix(v, suffix)), nil
 			}
 		}
 	}
-	return normalizeHelmVersion(tag)
+	return "", fmt.Errorf("invalid get.helm.sh URL %s, to install a specific version use the full release URL, e.g. %s", u.String(), helmDownloadURL("v3.16.3"))
 }
 
 func newHelm(u *url.URL) (Provider, error) {
+	tag, err := parseHelmTag(u)
+	if err != nil {
+		return nil, err
+	}
 	return &httpReleaseProvider{
 		id:  "helm",
-		tag: parseHelmTag(u),
+		tag: tag,
 		src: &helm{client: httpclient.Client},
 	}, nil
 }

--- a/pkg/providers/helm_test.go
+++ b/pkg/providers/helm_test.go
@@ -1,0 +1,86 @@
+package providers
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestHelmProviderRouting(t *testing.T) {
+	cases := []struct {
+		url      string
+		provider string
+	}{
+		{"github.com/helm/helm", ""},
+		{"https://github.com/helm/helm/releases/tag/v3.16.3", ""},
+		{"get.helm.sh", ""},
+		{"github.com/helm/helm", "helm"},
+	}
+	for _, c := range cases {
+		p, err := New(c.url, c.provider)
+		if err != nil {
+			t.Fatalf("New(%q, %q) returned error: %v", c.url, c.provider, err)
+		}
+		if p.GetID() != "helm" {
+			t.Errorf("New(%q, %q) = provider %q, want helm", c.url, c.provider, p.GetID())
+		}
+	}
+}
+
+func TestHelmProviderDoesNotHijackOtherRepos(t *testing.T) {
+	// Repos merely prefixed with "helm/helm" must not resolve to the helm
+	// provider (e.g. helm/helm-mapkubeapis ships assets on GitHub).
+	p, err := New("github.com/helm/helm-mapkubeapis", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.GetID() == "helm" {
+		t.Errorf("helm/helm-mapkubeapis incorrectly routed to helm provider")
+	}
+}
+
+func TestHelmTagExtraction(t *testing.T) {
+	u, _ := url.Parse("https://github.com/helm/helm/releases/tag/v3.16.3")
+	p, err := newHelm(u)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := p.(*helm)
+	if h.tag != "v3.16.3" {
+		t.Errorf("tag = %q, want v3.16.3", h.tag)
+	}
+}
+
+func TestHelmCandidates(t *testing.T) {
+	u, _ := url.Parse("https://get.helm.sh")
+	p, _ := newHelm(u)
+	h := p.(*helm)
+
+	cs := h.candidates("v3.16.3")
+	if len(cs) != len(helmPlatforms) {
+		t.Fatalf("got %d candidates, want %d", len(cs), len(helmPlatforms))
+	}
+
+	want := "https://get.helm.sh/helm-v3.16.3-linux-amd64.tar.gz"
+	found := false
+	for _, c := range cs {
+		if c.URL == want {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("candidates missing %q", want)
+	}
+}
+
+func TestNormalizeHelmVersion(t *testing.T) {
+	cases := map[string]string{
+		"3.16.3":  "v3.16.3",
+		"v3.16.3": "v3.16.3",
+		"":        "",
+	}
+	for in, want := range cases {
+		if got := normalizeHelmVersion(in); got != want {
+			t.Errorf("normalizeHelmVersion(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/pkg/providers/helm_test.go
+++ b/pkg/providers/helm_test.go
@@ -11,10 +11,10 @@ func TestHelmProviderRouting(t *testing.T) {
 		url      string
 		provider string
 	}{
-		{"github.com/helm/helm", ""},
-		{"https://github.com/helm/helm/releases/tag/v3.16.3", ""},
 		{"get.helm.sh", ""},
-		{"github.com/helm/helm", "helm"},
+		{"https://get.helm.sh/v3.16.3", ""},
+		{"https://get.helm.sh/helm-v3.16.3-linux-amd64.tar.gz", ""},
+		{"get.helm.sh", "helm"},
 	}
 	for _, c := range cases {
 		p, err := New(c.url, c.provider)
@@ -27,24 +27,29 @@ func TestHelmProviderRouting(t *testing.T) {
 	}
 }
 
-func TestHelmProviderDoesNotHijackOtherRepos(t *testing.T) {
-	// Repos merely prefixed with "helm/helm" must not resolve to the helm
-	// provider (e.g. helm/helm-mapkubeapis ships assets on GitHub).
-	p, err := New("github.com/helm/helm-mapkubeapis", "")
+func TestHelmProviderDoesNotHijackGitHub(t *testing.T) {
+	// GitHub URLs stay on the github provider; only get.helm.sh (or an
+	// explicit --provider helm) selects the helm provider.
+	p, err := New("github.com/helm/helm", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if p.GetID() == "helm" {
-		t.Errorf("helm/helm-mapkubeapis incorrectly routed to helm provider")
+	if p.GetID() != "github" {
+		t.Errorf("github.com/helm/helm routed to %q, want github", p.GetID())
 	}
 }
 
 func TestHelmTagExtraction(t *testing.T) {
 	cases := map[string]string{
-		"https://github.com/helm/helm/releases/tag/v3.16.3": "v3.16.3",
+		"https://get.helm.sh/v3.16.3": "v3.16.3",
 		// tags are normalized to carry the leading "v"
-		"https://github.com/helm/helm/releases/tag/3.16.3": "v3.16.3",
-		"https://github.com/helm/helm":                     "",
+		"https://get.helm.sh/3.16.3": "v3.16.3",
+		// release download URLs pin their version, whatever the platform
+		"https://get.helm.sh/helm-v3.16.3-linux-amd64.tar.gz":      "v3.16.3",
+		"https://get.helm.sh/helm-v3.16.3-windows-amd64.zip":       "v3.16.3",
+		"https://get.helm.sh/helm-v3.17.0-rc.1-linux-arm64.tar.gz": "v3.17.0-rc.1",
+		"https://get.helm.sh":                     "",
+		"https://get.helm.sh/helm-latest-version": "",
 	}
 	for in, want := range cases {
 		u, _ := url.Parse(in)
@@ -58,7 +63,7 @@ func TestHelmTagExtraction(t *testing.T) {
 // latestVersion resolves back to the helm provider with the same tag, since
 // the update command re-instantiates providers from that URL.
 func TestHelmLatestVersionURLRoundTrip(t *testing.T) {
-	u := fmt.Sprintf("%s/%s", helmReleasesURL, "v4.2.2")
+	u := fmt.Sprintf("%s/%s", helmDownloadBase, "v4.2.2")
 	p, err := New(u, "")
 	if err != nil {
 		t.Fatalf("New(%q) returned error: %v", u, err)

--- a/pkg/providers/helm_test.go
+++ b/pkg/providers/helm_test.go
@@ -1,6 +1,7 @@
 package providers
 
 import (
+	"fmt"
 	"net/url"
 	"testing"
 )
@@ -39,21 +40,40 @@ func TestHelmProviderDoesNotHijackOtherRepos(t *testing.T) {
 }
 
 func TestHelmTagExtraction(t *testing.T) {
-	u, _ := url.Parse("https://github.com/helm/helm/releases/tag/v3.16.3")
-	p, err := newHelm(u)
-	if err != nil {
-		t.Fatal(err)
+	cases := map[string]string{
+		"https://github.com/helm/helm/releases/tag/v3.16.3": "v3.16.3",
+		// tags are normalized to carry the leading "v"
+		"https://github.com/helm/helm/releases/tag/3.16.3": "v3.16.3",
+		"https://github.com/helm/helm":                     "",
 	}
-	h := p.(*helm)
-	if h.tag != "v3.16.3" {
-		t.Errorf("tag = %q, want v3.16.3", h.tag)
+	for in, want := range cases {
+		u, _ := url.Parse(in)
+		if got := parseHelmTag(u); got != want {
+			t.Errorf("parseHelmTag(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestHelmLatestVersionURLRoundTrip ensures the URL shape returned by
+// latestVersion resolves back to the helm provider with the same tag, since
+// the update command re-instantiates providers from that URL.
+func TestHelmLatestVersionURLRoundTrip(t *testing.T) {
+	u := fmt.Sprintf("%s/%s", helmReleasesURL, "v4.2.2")
+	p, err := New(u, "")
+	if err != nil {
+		t.Fatalf("New(%q) returned error: %v", u, err)
+	}
+	hp, ok := p.(*httpReleaseProvider)
+	if !ok || hp.GetID() != "helm" {
+		t.Fatalf("New(%q) = %T (%s), want helm httpReleaseProvider", u, p, p.GetID())
+	}
+	if hp.tag != "v4.2.2" {
+		t.Errorf("tag = %q, want v4.2.2", hp.tag)
 	}
 }
 
 func TestHelmCandidates(t *testing.T) {
-	u, _ := url.Parse("https://get.helm.sh")
-	p, _ := newHelm(u)
-	h := p.(*helm)
+	h := &helm{}
 
 	cs := h.candidates("v3.16.3")
 	if len(cs) != len(helmPlatforms) {

--- a/pkg/providers/helm_test.go
+++ b/pkg/providers/helm_test.go
@@ -1,7 +1,6 @@
 package providers
 
 import (
-	"fmt"
 	"net/url"
 	"testing"
 )
@@ -12,7 +11,6 @@ func TestHelmProviderRouting(t *testing.T) {
 		provider string
 	}{
 		{"get.helm.sh", ""},
-		{"https://get.helm.sh/v3.16.3", ""},
 		{"https://get.helm.sh/helm-v3.16.3-linux-amd64.tar.gz", ""},
 		{"get.helm.sh", "helm"},
 	}
@@ -41,20 +39,35 @@ func TestHelmProviderDoesNotHijackGitHub(t *testing.T) {
 
 func TestHelmTagExtraction(t *testing.T) {
 	cases := map[string]string{
-		"https://get.helm.sh/v3.16.3": "v3.16.3",
-		// tags are normalized to carry the leading "v"
-		"https://get.helm.sh/3.16.3": "v3.16.3",
 		// release download URLs pin their version, whatever the platform
 		"https://get.helm.sh/helm-v3.16.3-linux-amd64.tar.gz":      "v3.16.3",
 		"https://get.helm.sh/helm-v3.16.3-windows-amd64.zip":       "v3.16.3",
 		"https://get.helm.sh/helm-v3.17.0-rc.1-linux-arm64.tar.gz": "v3.17.0-rc.1",
-		"https://get.helm.sh":                     "",
-		"https://get.helm.sh/helm-latest-version": "",
+		"https://get.helm.sh": "",
 	}
 	for in, want := range cases {
 		u, _ := url.Parse(in)
-		if got := parseHelmTag(u); got != want {
+		got, err := parseHelmTag(u)
+		if err != nil {
+			t.Errorf("parseHelmTag(%q) returned error: %v", in, err)
+		} else if got != want {
 			t.Errorf("parseHelmTag(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestHelmTagExtractionRejectsInvalidURLs(t *testing.T) {
+	// get.helm.sh only serves release download URLs; anything else must be
+	// rejected instead of silently installing the latest version.
+	cases := []string{
+		"https://get.helm.sh/v3.16.3",
+		"https://get.helm.sh/3.16.3",
+		"https://get.helm.sh/helm-latest-version",
+		"https://get.helm.sh/helm-v3.16.3-linux-amd64.tar.gz.sha256sum",
+	}
+	for _, in := range cases {
+		if _, err := New(in, ""); err == nil {
+			t.Errorf("New(%q) succeeded, want error", in)
 		}
 	}
 }
@@ -63,7 +76,7 @@ func TestHelmTagExtraction(t *testing.T) {
 // latestVersion resolves back to the helm provider with the same tag, since
 // the update command re-instantiates providers from that URL.
 func TestHelmLatestVersionURLRoundTrip(t *testing.T) {
-	u := fmt.Sprintf("%s/%s", helmDownloadBase, "v4.2.2")
+	u := helmDownloadURL("v4.2.2")
 	p, err := New(u, "")
 	if err != nil {
 		t.Fatalf("New(%q) returned error: %v", u, err)

--- a/pkg/providers/httprelease.go
+++ b/pkg/providers/httprelease.go
@@ -22,10 +22,9 @@ type httpSource interface {
 // the flow shared by all HTTP release sources: version selection, asset
 // scoring and archive processing.
 type httpReleaseProvider struct {
-	id   string // provider ID persisted in the config
-	name string // binary name used for asset scoring and logging
-	tag  string // version parsed from the install URL, if any
-	src  httpSource
+	id  string // provider ID persisted in the config, also used for asset scoring and logging
+	tag string // version parsed from the install URL, if any
+	src httpSource
 }
 
 func (p *httpReleaseProvider) GetID() string {
@@ -40,9 +39,9 @@ func (p *httpReleaseProvider) Fetch(opts *FetchOpts) (*File, error) {
 	}
 
 	if version == "" {
-		log.Infof("Getting latest release for %s", p.name)
+		log.Infof("Getting latest release for %s", p.id)
 	} else {
-		log.Infof("Getting %s release for %s", version, p.name)
+		log.Infof("Getting %s release for %s", version, p.id)
 	}
 
 	version, candidates, err := p.src.fetchRelease(version)
@@ -52,7 +51,7 @@ func (p *httpReleaseProvider) Fetch(opts *FetchOpts) (*File, error) {
 
 	f := assets.NewFilter(&assets.FilterOpts{SkipScoring: opts.All, PackagePath: opts.PackagePath, SkipPathCheck: opts.SkipPatchCheck, PackageName: opts.PackageName, NamePattern: opts.NamePattern})
 
-	gf, err := f.FilterAssets(p.name, candidates)
+	gf, err := f.FilterAssets(p.id, candidates)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/providers/httprelease.go
+++ b/pkg/providers/httprelease.go
@@ -1,0 +1,73 @@
+package providers
+
+import (
+	"github.com/caarlos0/log"
+	"github.com/marcosnils/bin/pkg/assets"
+)
+
+// httpSource is a release source that publishes binaries on a plain HTTP
+// endpoint (e.g. releases.hashicorp.com, get.helm.sh). It only resolves
+// versions and enumerates downloadable assets; the shared asset-selection
+// and download flow lives in httpReleaseProvider.
+type httpSource interface {
+	// fetchRelease resolves version ("" means latest) to its canonical
+	// form and the list of downloadable assets for it.
+	fetchRelease(version string) (string, []*assets.Asset, error)
+	// latestVersion returns the latest version and a URL that, when
+	// passed back to providers.New, resolves to that same release.
+	latestVersion() (string, string, error)
+}
+
+// httpReleaseProvider implements Provider on top of an httpSource, handling
+// the flow shared by all HTTP release sources: version selection, asset
+// scoring and archive processing.
+type httpReleaseProvider struct {
+	id   string // provider ID persisted in the config
+	name string // binary name used for asset scoring and logging
+	tag  string // version parsed from the install URL, if any
+	src  httpSource
+}
+
+func (p *httpReleaseProvider) GetID() string {
+	return p.id
+}
+
+func (p *httpReleaseProvider) Fetch(opts *FetchOpts) (*File, error) {
+	version := p.tag
+	if len(opts.Version) > 0 {
+		// this is used by the `ensure` command
+		version = opts.Version
+	}
+
+	if version == "" {
+		log.Infof("Getting latest release for %s", p.name)
+	} else {
+		log.Infof("Getting %s release for %s", version, p.name)
+	}
+
+	version, candidates, err := p.src.fetchRelease(version)
+	if err != nil {
+		return nil, err
+	}
+
+	f := assets.NewFilter(&assets.FilterOpts{SkipScoring: opts.All, PackagePath: opts.PackagePath, SkipPathCheck: opts.SkipPatchCheck, PackageName: opts.PackageName, NamePattern: opts.NamePattern})
+
+	gf, err := f.FilterAssets(p.name, candidates)
+	if err != nil {
+		return nil, err
+	}
+
+	outFile, err := f.ProcessURL(gf)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO calculate file hash. Not sure if we can / should do it here
+	// since we don't want to read the file unnecessarily. Additionally, sometimes
+	// releases have .sha256 files, so it'd be nice to check for those also
+	return &File{Data: outFile.Source, Name: outFile.Name, Version: version, PackagePath: outFile.PackagePath}, nil
+}
+
+func (p *httpReleaseProvider) GetLatestVersion() (string, string, error) {
+	return p.src.latestVersion()
+}

--- a/pkg/providers/httprelease.go
+++ b/pkg/providers/httprelease.go
@@ -10,11 +10,7 @@ import (
 // versions and enumerates downloadable assets; the shared asset-selection
 // and download flow lives in httpReleaseProvider.
 type httpSource interface {
-	// fetchRelease resolves version ("" means latest) to its canonical
-	// form and the list of downloadable assets for it.
 	fetchRelease(version string) (string, []*assets.Asset, error)
-	// latestVersion returns the latest version and a URL that, when
-	// passed back to providers.New, resolves to that same release.
 	latestVersion() (string, string, error)
 }
 
@@ -22,8 +18,8 @@ type httpSource interface {
 // the flow shared by all HTTP release sources: version selection, asset
 // scoring and archive processing.
 type httpReleaseProvider struct {
-	id  string // provider ID persisted in the config, also used for asset scoring and logging
-	tag string // version parsed from the install URL, if any
+	id  string
+	tag string
 	src httpSource
 }
 

--- a/pkg/providers/providers.go
+++ b/pkg/providers/providers.go
@@ -76,7 +76,7 @@ func New(u, provider string) (Provider, error) {
 	// GitHub branch since github.com/helm/helm would otherwise be captured
 	// there.
 	helmPath := strings.TrimPrefix(purl.Path, "/")
-	if provider == "helm" || purl.Host == "get.helm.sh" || (purl.Host == "github.com" && (helmPath == "helm/helm" || strings.HasPrefix(helmPath, "helm/helm/")) {
+	if provider == "helm" || purl.Host == "get.helm.sh" || (purl.Host == "github.com" && (helmPath == "helm/helm" || strings.HasPrefix(helmPath, "helm/helm/"))) {
 		return newHelm(purl)
 	}
 

--- a/pkg/providers/providers.go
+++ b/pkg/providers/providers.go
@@ -71,15 +71,6 @@ func New(u, provider string) (Provider, error) {
 		return nil, err
 	}
 
-	// Helm publishes its binaries on get.helm.sh rather than as GitHub
-	// release assets, so it needs a dedicated provider. Match it before the
-	// GitHub branch since github.com/helm/helm would otherwise be captured
-	// there.
-	helmPath := strings.TrimPrefix(purl.Path, "/")
-	if provider == "helm" || purl.Host == "get.helm.sh" || (purl.Host == "github.com" && (helmPath == "helm/helm" || strings.HasPrefix(helmPath, "helm/helm/"))) {
-		return newHelm(purl)
-	}
-
 	if strings.Contains(purl.Host, "github") || provider == "github" {
 		return newGitHub(purl)
 	}
@@ -90,6 +81,10 @@ func New(u, provider string) (Provider, error) {
 
 	if strings.Contains(purl.Host, "codeberg") || provider == "codeberg" {
 		return newCodeberg(purl)
+	}
+
+	if strings.Contains(purl.Host, "get.helm.sh") || provider == "helm" {
+		return newHelm(purl)
 	}
 
 	if strings.Contains(purl.Host, "releases.hashicorp.com") || provider == "hashicorp" {

--- a/pkg/providers/providers.go
+++ b/pkg/providers/providers.go
@@ -76,7 +76,7 @@ func New(u, provider string) (Provider, error) {
 	// GitHub branch since github.com/helm/helm would otherwise be captured
 	// there.
 	helmPath := strings.TrimPrefix(purl.Path, "/")
-	if provider == "helm" || purl.Host == "get.helm.sh" || helmPath == "helm/helm" || strings.HasPrefix(helmPath, "helm/helm/") {
+	if provider == "helm" || purl.Host == "get.helm.sh" || (purl.Host == "github.com" && (helmPath == "helm/helm" || strings.HasPrefix(helmPath, "helm/helm/")) {
 		return newHelm(purl)
 	}
 

--- a/pkg/providers/providers.go
+++ b/pkg/providers/providers.go
@@ -71,6 +71,15 @@ func New(u, provider string) (Provider, error) {
 		return nil, err
 	}
 
+	// Helm publishes its binaries on get.helm.sh rather than as GitHub
+	// release assets, so it needs a dedicated provider. Match it before the
+	// GitHub branch since github.com/helm/helm would otherwise be captured
+	// there.
+	helmPath := strings.TrimPrefix(purl.Path, "/")
+	if provider == "helm" || purl.Host == "get.helm.sh" || helmPath == "helm/helm" || strings.HasPrefix(helmPath, "helm/helm/") {
+		return newHelm(purl)
+	}
+
 	if strings.Contains(purl.Host, "github") || provider == "github" {
 		return newGitHub(purl)
 	}


### PR DESCRIPTION
## What

Adds a dedicated `helm` provider so `bin install github.com/helm/helm` works.

## Why

Helm does **not** attach binaries to its GitHub releases — the release assets are only `.asc` signatures and checksums. The actual binaries are published on [get.helm.sh](https://get.helm.sh) (e.g. `https://get.helm.sh/helm-v3.16.3-linux-amd64.tar.gz`). As a result the existing GitHub provider finds the release but filters away every asset and fails with "Could not find any compatible files".

This is the same situation the `hashicorp` provider already handles for `releases.hashicorp.com`, so the implementation follows that pattern.

## How

- New `pkg/providers/helm.go`:
  - `GetLatestVersion()` reads `https://get.helm.sh/helm-latest-version`.
  - `Fetch()` builds the candidate download URLs for the platforms Helm publishes and reuses the shared `assets` scoring + archive handling to select and unpack the correct binary (the tarballs contain an `os-arch/helm` entry, which `ProcessURL` unpacks to the executable).
  - Supports pinned versions via release-tag URLs (`github.com/helm/helm/releases/tag/v3.16.3`) and the `ensure` command's `--version`.
- `pkg/providers/providers.go`: route `github.com/helm/helm`, `get.helm.sh`, and `--provider helm` to the new provider (matched before the GitHub branch, with an exact `helm/helm` path check so repos like `helm/helm-mapkubeapis` are unaffected).
- Unit tests in `pkg/providers/helm_test.go` (routing, tag extraction, candidate URLs, version normalization).
- README: new "Helm" section and entry in the sources list.

## Testing

- `go build ./...`, `go vet ./pkg/providers/`, and `go test ./pkg/providers/` all pass.
- End-to-end verified on darwin/arm64:

```
$ bin install github.com/helm/helm ./helm
  • Getting v4.2.2 release for helm
  • Starting download of https://get.helm.sh/helm-v4.2.2-darwin-arm64.tar.gz
  • Done installing helm v4.2.2
$ ./helm version
version.BuildInfo{Version:"v4.2.2", ...}

$ bin install github.com/helm/helm/releases/tag/v3.16.3 ./helm-3163
  • Done installing helm v3.16.3
```
