### PR TITLE
feat: add `-x/--exclude` flag to skip packages during update

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ scoop install extras/bin
 | --------------------------- | ------------------------------------------ | -------------------------------- |
 | `bin install <repo> [path]` | Install binary from GitHub or Docker       | `bin install github.com/cli/cli` |
 | `bin list`                  | List installed binaries and versions       | `bin list`                       |
-| `bin update [binary...]`    | Update binaries (all or specified)         | `bin update`                     |
+| `bin update [binary...]`    | Update binaries (all or specified); use `-x` to exclude | `bin update -x kubectl` |
 | `bin remove <binary...>`    | Remove one or more binaries                | `bin remove gh kubectl`          |
 | `bin ensure`                | Ensure all configured binaries are present | `bin ensure`                     |
 | `bin pin <binary...>`       | Pin current version (prevent updates)      | `bin pin terraform`              |

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ scoop install extras/bin
 | --------------------------- | ------------------------------------------ | -------------------------------- |
 | `bin install <repo> [path]` | Install binary from GitHub or Docker       | `bin install github.com/cli/cli` |
 | `bin list`                  | List installed binaries and versions       | `bin list`                       |
-| `bin update [binary...]`    | Update binaries (all or specified); use `-x` to exclude | `bin update -x kubectl` |
+| `bin update [binary...]`    | Update binaries (all or specified)         | `bin update`                     |
 | `bin remove <binary...>`    | Remove one or more binaries                | `bin remove gh kubectl`          |
 | `bin ensure`                | Ensure all configured binaries are present | `bin ensure`                     |
 | `bin pin <binary...>`       | Pin current version (prevent updates)      | `bin pin terraform`              |

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -24,6 +24,7 @@ type updateOpts struct {
 	all             bool
 	skipPathCheck   bool
 	continueOnError bool
+	exclude         []string
 }
 
 type updateInfo struct{ version, url string }
@@ -65,9 +66,22 @@ func newUpdateCmd() *updateCmd {
 				binsToProcess = cfg.Bins
 			}
 
+			excluded := map[string]bool{}
+			for _, e := range root.opts.exclude {
+				bin, err := getBinPath(e)
+				if err != nil {
+					return err
+				}
+				excluded[bin] = true
+			}
+
 			updateFailures := map[*config.Binary]error{}
 
 			for p, b := range binsToProcess {
+				if excluded[p] {
+					log.Infof("%s is excluded from updates", p)
+					continue
+				}
 				if cfg.Bins[p].Pinned {
 					log.Infof("%s is a pinned binary", p)
 					continue
@@ -164,6 +178,7 @@ func newUpdateCmd() *updateCmd {
 	root.cmd.Flags().BoolVarP(&root.opts.all, "all", "a", false, "Show all possible download options (skip scoring & filtering)")
 	root.cmd.Flags().BoolVarP(&root.opts.skipPathCheck, "skip-path-check", "p", false, "Skips path checking when looking into packages")
 	root.cmd.Flags().BoolVarP(&root.opts.continueOnError, "continue-on-error", "c", false, "Continues to update next package if an error is encountered")
+	root.cmd.Flags().StringSliceVarP(&root.opts.exclude, "exclude", "x", nil, "Exclude binaries from the update (can be repeated)")
 	return root
 }
 


### PR DESCRIPTION
Adds an exclude flag to the update command so specific binaries can be skipped during bulk updates, e.g. `bin update -x /some/path/binary`. The flag can be repeated and accepts both binary names and full paths, resolved the same way as positional arguments.

Resolves marcosnils/bin#166