### PR TITLE
feat: add package update cooldowns

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ scoop install extras/bin
 | `bin pin <binary...>`       | Pin current version (prevent updates)      | `bin pin terraform`              |
 | `bin unpin <binary...>`     | Unpin binaries (allow updates)             | `bin unpin terraform`            |
 | `bin prune`                 | Remove missing binaries from database      | `bin prune`                      |
+| `bin cooldown ...`          | Manage update cooldown periods             | `bin cooldown set 24h`           |
 | `bin help`                  | Show help for any command                  | `bin help install`               |
 
 **Tips**: if `bin` is unable to found the right package, try `bin install -a` to show all possible download options (skip scoring & filtering).
@@ -223,6 +224,54 @@ Ensure `go` is present in your `PATH`.
 ```shell
 bin install goinstall://github.com/jrhouston/tfk8s@v0.1.8
 ```
+
+## ❄️ Cooldowns
+
+A **cooldown** delays updating a binary until a configured period has elapsed
+since the target version was published. This mitigates supply-chain attacks that
+rely on quick adoption of a freshly published (malicious) release: `bin update`
+will skip a new version until it has been public for at least the cooldown
+duration, giving the community time to detect problems.
+
+Cooldowns are **opt-in** (disabled by default) and are only enforced for
+providers that expose a publish date: **GitHub**, **GitLab**, **Codeberg** and
+**Go Install**. For other providers (Docker, HTTP releases such as Helm and
+HashiCorp) a configured cooldown is displayed but not enforced.
+
+### Duration format
+
+Durations accept a friendly format: `24h`, `90m`, `1h30m`, `7d`, `2w`. Use `0`
+to disable.
+
+### Usage
+
+```bash
+# set the global default cooldown (applies to all binaries)
+bin cooldown set 24h
+
+# set a per-package override
+bin cooldown set fzf 7d
+
+# show the effective cooldown for the default, or a specific binary
+bin cooldown get
+bin cooldown get fzf
+
+# show the default plus all per-package overrides
+bin cooldown
+
+# clear a per-package override (revert to the default)
+bin cooldown unset fzf
+
+# clear the global default (revert to built-in default: disabled)
+bin cooldown unset
+```
+
+Cooldowns also appear in `bin ls` under the `Cooldown` column. A trailing `*`
+marks a per-package override; `n/a` means the binary's provider has no publish
+date, so the cooldown cannot be enforced.
+
+The effective cooldown is resolved in order: per-package override → global
+default → built-in default (disabled).
 
 ## 🔧 Configuration
 

--- a/cmd/cooldown.go
+++ b/cmd/cooldown.go
@@ -1,0 +1,237 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"time"
+
+	"github.com/caarlos0/log"
+	"github.com/fatih/color"
+	"github.com/marcosnils/bin/pkg/config"
+	"github.com/marcosnils/bin/pkg/providers"
+	"github.com/spf13/cobra"
+)
+
+type cooldownCmd struct {
+	cmd *cobra.Command
+}
+
+// newCooldownCmd builds the `bin cooldown` command tree. A cooldown holds back
+// updating a binary until the configured period has elapsed since the target
+// version was published, mitigating supply-chain attacks that rely on quick
+// adoption of a freshly published (malicious) release.
+func newCooldownCmd() *cooldownCmd {
+	root := &cooldownCmd{}
+
+	cmd := &cobra.Command{
+		Use:   "cooldown",
+		Short: "Manage update cooldown periods",
+		Long: `Manage update cooldown periods.
+
+A cooldown delays updating a binary until the given duration has elapsed since
+the new version was published, giving the community time to detect malicious
+releases. Durations accept a friendly format: e.g. 24h, 90m, 7d, 2w. Set 0 to
+disable. Cooldowns are opt-in and default to disabled.
+
+Cooldowns can only be enforced for providers that expose a publish date
+(GitHub, GitLab, Codeberg, goinstall); they are ignored for others.`,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCooldownList()
+		},
+	}
+
+	cmd.AddCommand(
+		newCooldownListCmd(),
+		newCooldownGetCmd(),
+		newCooldownSetCmd(),
+		newCooldownUnsetCmd(),
+	)
+
+	root.cmd = cmd
+	return root
+}
+
+func newCooldownListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:           "list",
+		Aliases:       []string{"ls"},
+		Short:         "Show the default cooldown and any per-package overrides",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCooldownList()
+		},
+	}
+}
+
+func newCooldownGetCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:           "get [binary]",
+		Short:         "Show the effective cooldown for the default or a binary",
+		Args:          cobra.MaximumNArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				d, err := config.EffectiveCooldown(nil)
+				if err != nil {
+					return err
+				}
+				log.Infof("default cooldown: %s", config.FormatCooldown(d))
+				return nil
+			}
+
+			bin, err := getBinPath(args[0])
+			if err != nil {
+				return err
+			}
+			b := config.Get().Bins[bin]
+			eff, err := config.EffectiveCooldown(b)
+			if err != nil {
+				return err
+			}
+
+			source := "default"
+			if b.Cooldown != "" {
+				source = "override"
+			}
+			log.Infof("%s cooldown: %s (%s)", bin, config.FormatCooldown(eff), source)
+			if !providers.SupportsPublishDate(b.Provider) {
+				log.Warnf("provider %q has no publish date; cooldown is not enforced for this binary", b.Provider)
+			}
+			return nil
+		},
+	}
+}
+
+func newCooldownSetCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "set [binary] <duration>",
+		Short: "Set the default cooldown, or a per-package override",
+		Long: `Set the default cooldown, or a per-package override.
+
+With a single argument the global default is set:
+    bin cooldown set 24h
+
+With two arguments a per-package override is set:
+    bin cooldown set fzf 7d
+
+Use 0 to disable.`,
+		Args:          cobra.RangeArgs(1, 2),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 1 {
+				// Global default. Validate before persisting so a mistyped
+				// binary name isn't silently stored as the default.
+				if _, err := config.ParseCooldown(args[0]); err != nil {
+					return fmt.Errorf("%w (to set a per-package cooldown use: bin cooldown set <binary> <duration>)", err)
+				}
+				if err := config.SetDefaultCooldown(args[0]); err != nil {
+					return err
+				}
+				log.Infof("default cooldown set to %s", config.FormatCooldown(mustParse(args[0])))
+				return nil
+			}
+
+			// Per-package override.
+			if _, err := config.ParseCooldown(args[1]); err != nil {
+				return err
+			}
+			bin, err := getBinPath(args[0])
+			if err != nil {
+				return err
+			}
+			b := config.Get().Bins[bin]
+			b.Cooldown = args[1]
+			if err := config.UpsertBinary(b); err != nil {
+				return err
+			}
+			log.Infof("cooldown for %s set to %s", bin, config.FormatCooldown(mustParse(args[1])))
+			if !providers.SupportsPublishDate(b.Provider) {
+				log.Warnf("provider %q has no publish date; cooldown is not enforced for this binary", b.Provider)
+			}
+			return nil
+		},
+	}
+}
+
+func newCooldownUnsetCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:           "unset [binary]",
+		Short:         "Clear the default cooldown, or a per-package override",
+		Args:          cobra.MaximumNArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				if err := config.SetDefaultCooldown(""); err != nil {
+					return err
+				}
+				log.Infof("default cooldown cleared")
+				return nil
+			}
+
+			bin, err := getBinPath(args[0])
+			if err != nil {
+				return err
+			}
+			b := config.Get().Bins[bin]
+			b.Cooldown = ""
+			if err := config.UpsertBinary(b); err != nil {
+				return err
+			}
+			log.Infof("cooldown override for %s cleared", bin)
+			return nil
+		},
+	}
+}
+
+// runCooldownList prints the resolved default cooldown followed by any binaries
+// carrying an explicit per-package override.
+func runCooldownList() error {
+	cfg := config.Get()
+
+	def, err := config.EffectiveCooldown(nil)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Default cooldown: %s\n", config.FormatCooldown(def))
+
+	overrides := []string{}
+	for k, b := range cfg.Bins {
+		if b.Cooldown != "" {
+			overrides = append(overrides, k)
+		}
+	}
+	sort.Strings(overrides)
+
+	if len(overrides) == 0 {
+		fmt.Println("No per-package overrides.")
+		return nil
+	}
+
+	fmt.Println("\nPer-package overrides:")
+	for _, k := range overrides {
+		b := cfg.Bins[k]
+		eff, err := config.EffectiveCooldown(b)
+		if err != nil {
+			return err
+		}
+		note := ""
+		if !providers.SupportsPublishDate(b.Provider) {
+			note = color.YellowString("  (not enforced: provider has no publish date)")
+		}
+		fmt.Printf("  %s  %s%s\n", os.ExpandEnv(b.Path), config.FormatCooldown(eff), note)
+	}
+	return nil
+}
+
+// mustParse parses an already-validated cooldown string for display purposes.
+func mustParse(s string) (d time.Duration) {
+	d, _ = config.ParseCooldown(s)
+	return d
+}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/marcosnils/bin/pkg/config"
+	"github.com/marcosnils/bin/pkg/providers"
 	"github.com/spf13/cobra"
 )
 
@@ -17,6 +18,25 @@ func _rPad(s string, width int) string {
 		return s
 	}
 	return s + strings.Repeat(" ", width-len(s))
+}
+
+// cooldownCell renders the Cooldown column value for a binary:
+//   - "-"   when the effective cooldown is disabled (0)
+//   - "n/a" when the provider can't supply a publish date (not enforceable)
+//   - "<dur>" otherwise, with a trailing "*" for an explicit per-package override
+func cooldownCell(b *config.Binary) string {
+	eff, err := config.EffectiveCooldown(b)
+	if err != nil || eff <= 0 {
+		return "-"
+	}
+	if !providers.SupportsPublishDate(b.Provider) {
+		return "n/a"
+	}
+	s := config.FormatCooldown(eff)
+	if b.Cooldown != "" {
+		s += "*"
+	}
+	return s
 }
 
 type listCmd struct {
@@ -41,8 +61,14 @@ func newListCmd() *listCmd {
 			}
 			sort.Strings(binPaths)
 
+			// Pre-compute the cooldown cell for each binary.
+			cooldowns := map[string]string{}
+			for _, k := range binPaths {
+				cooldowns[k] = cooldownCell(cfg.Bins[k])
+			}
+
 			// Calculate maximum length of each column
-			maxLengths := make([]int, 3)
+			maxLengths := make([]int, 4)
 			for _, k := range binPaths {
 				b := cfg.Bins[k]
 				p := os.ExpandEnv(b.Path)
@@ -58,18 +84,26 @@ func newListCmd() *listCmd {
 				if len(b.URL) > maxLengths[2] {
 					maxLengths[2] = len(b.URL)
 				}
+
+				if len(cooldowns[k]) > maxLengths[3] {
+					maxLengths[3] = len(cooldowns[k])
+				}
 			}
 
-			pL, vL, uL := maxLengths[0], maxLengths[1], maxLengths[2]
+			pL, vL, uL, cL := maxLengths[0], maxLengths[1], maxLengths[2], maxLengths[3]
 			// Reserve an extra column for the pin marker so that pinned and
 			// unpinned versions line up.
 			vL++
+			if cL < len("Cooldown") {
+				cL = len("Cooldown")
+			}
 			magentaItalic := color.New(color.FgMagenta, color.Italic).Sprint
 			// Leading space keeps the header aligned with the version text
 			// rather than the pin-marker column.
-			p, v, u, s := magentaItalic(_rPad(("Path"), pL)), magentaItalic(_rPad(" Version", vL)), magentaItalic(_rPad("URL", uL)), magentaItalic("Status")
+			p, v, u := magentaItalic(_rPad(("Path"), pL)), magentaItalic(_rPad(" Version", vL)), magentaItalic(_rPad("URL", uL))
+			c, s := magentaItalic(_rPad("Cooldown", cL)), magentaItalic("Status")
 
-			fmt.Printf("\n%s  %s  %s  %s", p, v, u, s)
+			fmt.Printf("\n%s  %s  %s  %s  %s", p, v, u, c, s)
 
 			for _, k := range binPaths {
 				b := cfg.Bins[k]
@@ -88,9 +122,11 @@ func newListCmd() *listCmd {
 					marker = "*"
 				}
 
-				fmt.Printf("\n%s  %s  %s  %s", _rPad(p, pL), _rPad(marker+b.Version, vL), _rPad(b.URL, uL), status)
+				fmt.Printf("\n%s  %s  %s  %s  %s", _rPad(p, pL), _rPad(marker+b.Version, vL), _rPad(b.URL, uL), _rPad(cooldowns[k], cL), status)
 			}
 			fmt.Print("\n\n")
+			// Legend: distinguish the pin marker from the cooldown-override marker.
+			fmt.Println("Version *: pinned   Cooldown *: per-package override   n/a: provider has no publish date")
 			return nil
 		},
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -90,6 +90,7 @@ func newRootCmd(version string, exit func(int)) *rootCmd {
 		newRemoveCmd().cmd,
 		newListCmd().cmd,
 		newPruneCmd().cmd,
+		newCooldownCmd().cmd,
 	)
 
 	root.cmd = cmd

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/caarlos0/log"
 	"github.com/fatih/color"
@@ -183,9 +184,13 @@ func newUpdateCmd() *updateCmd {
 	return root
 }
 
+// timeNow is a package-level clock indirection so cooldown enforcement can be
+// tested deterministically.
+var timeNow = time.Now
+
 func getLatestVersion(b *config.Binary, p providers.Provider) (*updateInfo, error) {
 	log.Debugf("Checking updates for %s", b.Path)
-	v, u, err := p.GetLatestVersion()
+	v, u, publishedAt, err := p.GetLatestVersion()
 	if err != nil {
 		return nil, fmt.Errorf("Error checking updates for %s, %w", b.Path, err)
 	}
@@ -198,6 +203,22 @@ func getLatestVersion(b *config.Binary, p providers.Provider) (*updateInfo, erro
 	vSemver, vSemverErr := version.NewVersion(v)
 	if bSemverErr == nil && vSemverErr == nil && vSemver.LessThanOrEqual(bSemver) {
 		return nil, nil
+	}
+
+	// Cooldown: hold back versions that were published more recently than the
+	// effective cooldown. Only enforced when the provider supplies a publish
+	// date; an unknown (zero) date is never gated.
+	cd, err := config.EffectiveCooldown(b)
+	if err != nil {
+		return nil, fmt.Errorf("invalid cooldown for %s: %w", b.Path, err)
+	}
+	if cd > 0 && !publishedAt.IsZero() {
+		if age := timeNow().Sub(publishedAt); age < cd {
+			log.Infof("%s %s -> %s held back by cooldown (published %s ago, cooldown %s, available in ~%s)",
+				b.Path, color.YellowString(b.Version), color.GreenString(v),
+				age.Round(time.Hour), config.FormatCooldown(cd), (cd - age).Round(time.Hour))
+			return nil, nil
+		}
 	}
 
 	log.Debugf("Found new version %s for %s at %s", v, b.Path, u)

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/marcosnils/bin/pkg/config"
 	"github.com/marcosnils/bin/pkg/providers"
@@ -12,11 +13,12 @@ type mockProvider struct {
 	providers.Provider
 	latestVersion    string
 	latestVersionURL string
+	publishedAt      time.Time
 	err              error
 }
 
-func (m mockProvider) GetLatestVersion() (string, string, error) {
-	return m.latestVersion, m.latestVersionURL, m.err
+func (m mockProvider) GetLatestVersion() (string, string, time.Time, error) {
+	return m.latestVersion, m.latestVersionURL, m.publishedAt, m.err
 }
 
 func (m mockProvider) GetID() string {
@@ -24,50 +26,108 @@ func (m mockProvider) GetID() string {
 }
 
 func TestGetLatestVersion(t *testing.T) {
+	// Pin the clock so cooldown windows are deterministic.
+	now := time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
+	timeNow = func() time.Time { return now }
+	t.Cleanup(func() { timeNow = time.Now })
+
 	type mockValues struct {
 		latestVersion    string
 		latestVersionURL string
+		publishedAt      time.Time
 		err              error
 	}
 	cases := []struct {
-		in  *config.Binary
-		m   mockValues
-		out *updateInfo
+		name string
+		in   *config.Binary
+		m    mockValues
+		out  *updateInfo
 	}{
 		{
-			&config.Binary{
+			name: "newer version available",
+			in: &config.Binary{
 				Path:       "/home/user/bin/launchpad",
 				Version:    "1.1.0",
 				URL:        "https://github.com/Mirantis/launchpad/releases/download/1.1.0/launchpad-linux-x64",
 				RemoteName: "launchpad-linux-x64",
 				Provider:   "github",
 			},
-			mockValues{"1.1.1", "https://github.com/Mirantis/launchpad/releases/download/1.1.1/launchpad-linux-x64", nil},
-			&updateInfo{
+			m: mockValues{"1.1.1", "https://github.com/Mirantis/launchpad/releases/download/1.1.1/launchpad-linux-x64", time.Time{}, nil},
+			out: &updateInfo{
 				version: "1.1.1",
 				url:     "https://github.com/Mirantis/launchpad/releases/download/1.1.1/launchpad-linux-x64",
 			},
 		},
 		{
-			&config.Binary{
+			name: "latest is older than current",
+			in: &config.Binary{
 				Path:       "/home/user/bin/launchpad",
 				Version:    "1.2.0-rc.1",
 				URL:        "https://github.com/Mirantis/launchpad/releases/download/1.2.0-rc.1/launchpad-linux-x64",
 				RemoteName: "launchpad-linux-x64",
 				Provider:   "github",
 			},
-			mockValues{"1.1.1", "https://github.com/Mirantis/launchpad/releases/download/1.1.1/launchpad-linux-x64", nil},
-			nil,
+			m:   mockValues{"1.1.1", "https://github.com/Mirantis/launchpad/releases/download/1.1.1/launchpad-linux-x64", time.Time{}, nil},
+			out: nil,
+		},
+		{
+			name: "held back by cooldown",
+			in: &config.Binary{
+				Path:       "/home/user/bin/launchpad",
+				Version:    "1.1.0",
+				URL:        "https://github.com/Mirantis/launchpad/releases/download/1.1.0/launchpad-linux-x64",
+				RemoteName: "launchpad-linux-x64",
+				Provider:   "github",
+				Cooldown:   "24h",
+			},
+			// published 1h ago -> within the 24h cooldown
+			m:   mockValues{"1.1.1", "https://github.com/Mirantis/launchpad/releases/download/1.1.1/launchpad-linux-x64", now.Add(-1 * time.Hour), nil},
+			out: nil,
+		},
+		{
+			name: "cooldown elapsed",
+			in: &config.Binary{
+				Path:       "/home/user/bin/launchpad",
+				Version:    "1.1.0",
+				URL:        "https://github.com/Mirantis/launchpad/releases/download/1.1.0/launchpad-linux-x64",
+				RemoteName: "launchpad-linux-x64",
+				Provider:   "github",
+				Cooldown:   "24h",
+			},
+			// published 48h ago -> past the 24h cooldown
+			m: mockValues{"1.1.1", "https://github.com/Mirantis/launchpad/releases/download/1.1.1/launchpad-linux-x64", now.Add(-48 * time.Hour), nil},
+			out: &updateInfo{
+				version: "1.1.1",
+				url:     "https://github.com/Mirantis/launchpad/releases/download/1.1.1/launchpad-linux-x64",
+			},
+		},
+		{
+			name: "cooldown set but publish date unknown",
+			in: &config.Binary{
+				Path:       "/home/user/bin/launchpad",
+				Version:    "1.1.0",
+				URL:        "https://github.com/Mirantis/launchpad/releases/download/1.1.0/launchpad-linux-x64",
+				RemoteName: "launchpad-linux-x64",
+				Provider:   "github",
+				Cooldown:   "24h",
+			},
+			// zero publish time -> cooldown is not enforced
+			m: mockValues{"1.1.1", "https://github.com/Mirantis/launchpad/releases/download/1.1.1/launchpad-linux-x64", time.Time{}, nil},
+			out: &updateInfo{
+				version: "1.1.1",
+				url:     "https://github.com/Mirantis/launchpad/releases/download/1.1.1/launchpad-linux-x64",
+			},
 		},
 	}
 
 	for _, c := range cases {
-		p := mockProvider{latestVersion: c.m.latestVersion, latestVersionURL: c.m.latestVersionURL, err: c.m.err}
-		if v, err := getLatestVersion(c.in, p); err != nil {
-			t.Fatalf("Error during getLatestVersion(%#v, %#v): %v", c.in, p, err)
-		} else if !reflect.DeepEqual(v, c.out) {
-			t.Fatalf("For case %#v: %#v does not match %#v", c.in, v, c.out)
-		}
+		t.Run(c.name, func(t *testing.T) {
+			p := mockProvider{latestVersion: c.m.latestVersion, latestVersionURL: c.m.latestVersionURL, publishedAt: c.m.publishedAt, err: c.m.err}
+			if v, err := getLatestVersion(c.in, p); err != nil {
+				t.Fatalf("Error during getLatestVersion(%#v, %#v): %v", c.in, p, err)
+			} else if !reflect.DeepEqual(v, c.out) {
+				t.Fatalf("For case %q: %#v does not match %#v", c.name, v, c.out)
+			}
+		})
 	}
-
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,8 +20,11 @@ type config struct {
 	// DefaultPath might not be expanded so it's important that
 	// the caller expands this variable with os.ExpandEnv(string)
 	// if necessary
-	DefaultPath string             `json:"default_path"`
-	Bins        map[string]*Binary `json:"bins"`
+	DefaultPath string `json:"default_path"`
+	// DefaultCooldown is the global cooldown applied before updating to a
+	// newly published version (e.g. "24h", "7d"). Empty means unset.
+	DefaultCooldown string             `json:"default_cooldown,omitempty"`
+	Bins            map[string]*Binary `json:"bins"`
 }
 
 type Binary struct {
@@ -39,6 +42,9 @@ type Binary struct {
 	// re-used to default the same artefact when upgrading
 	SelectedAsset string `json:"selected_asset"`
 	Pinned        bool   `json:"pinned"`
+	// Cooldown is a per-binary override of the global DefaultCooldown
+	// (e.g. "24h", "7d"). Empty means inherit the default.
+	Cooldown string `json:"cooldown,omitempty"`
 }
 
 func CheckAndLoad() error {

--- a/pkg/config/cooldown.go
+++ b/pkg/config/cooldown.go
@@ -1,0 +1,98 @@
+package config
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// builtinDefaultCooldown is the cooldown used when neither a per-binary override
+// nor a global default is configured. It is 0 (disabled) on purpose: cooldowns
+// are opt-in so that upgrading bin never silently starts blocking updates.
+// Users enable protection with `bin cooldown set 24h`.
+const builtinDefaultCooldown time.Duration = 0
+
+// ParseCooldown parses a human-friendly cooldown string into a time.Duration.
+//
+// Accepted forms:
+//   - ""  or "0"           -> 0 (disabled)
+//   - "<n>d" / "<n>w"      -> n days / n weeks
+//   - anything else        -> time.ParseDuration (e.g. "24h", "90m", "1h30m")
+//
+// time.ParseDuration does not understand day ("d") or week ("w") units, which
+// is why they are handled explicitly here. Negative durations are rejected.
+func ParseCooldown(s string) (time.Duration, error) {
+	s = strings.TrimSpace(s)
+	if s == "" || s == "0" {
+		return 0, nil
+	}
+
+	var d time.Duration
+	var err error
+	switch {
+	case strings.HasSuffix(s, "d"):
+		d, err = parseUnit(s, "d", 24*time.Hour)
+	case strings.HasSuffix(s, "w"):
+		d, err = parseUnit(s, "w", 7*24*time.Hour)
+	default:
+		d, err = time.ParseDuration(s)
+	}
+	if err != nil {
+		return 0, fmt.Errorf("invalid cooldown %q: %w", s, err)
+	}
+	if d < 0 {
+		return 0, fmt.Errorf("invalid cooldown %q: must not be negative", s)
+	}
+	return d, nil
+}
+
+// parseUnit parses "<n><suffix>" as n*unit.
+func parseUnit(s, suffix string, unit time.Duration) (time.Duration, error) {
+	n, err := strconv.Atoi(strings.TrimSuffix(s, suffix))
+	if err != nil {
+		return 0, err
+	}
+	return time.Duration(n) * unit, nil
+}
+
+// FormatCooldown renders a duration back to the shortest sensible unit for
+// display. Whole weeks/days are shown as "Nw"/"Nd"; 0 is "disabled"; everything
+// else falls back to time.Duration.String() (e.g. "1h30m0s").
+func FormatCooldown(d time.Duration) string {
+	switch {
+	case d <= 0:
+		return "disabled"
+	case d%(7*24*time.Hour) == 0:
+		return fmt.Sprintf("%dw", d/(7*24*time.Hour))
+	case d%(24*time.Hour) == 0:
+		return fmt.Sprintf("%dd", d/(24*time.Hour))
+	default:
+		return d.String()
+	}
+}
+
+// EffectiveCooldown resolves the cooldown that applies to a binary using the
+// order: per-binary override -> global default -> built-in default.
+func EffectiveCooldown(b *Binary) (time.Duration, error) {
+	if b != nil && b.Cooldown != "" {
+		return ParseCooldown(b.Cooldown)
+	}
+	if cfg.DefaultCooldown != "" {
+		return ParseCooldown(cfg.DefaultCooldown)
+	}
+	return builtinDefaultCooldown, nil
+}
+
+// SetDefaultCooldown validates and persists the global default cooldown.
+// An empty string clears it (reverting to the built-in default).
+func SetDefaultCooldown(s string) error {
+	s = strings.TrimSpace(s)
+	if s != "" {
+		if _, err := ParseCooldown(s); err != nil {
+			return err
+		}
+	}
+	cfg.DefaultCooldown = s
+	return write()
+}

--- a/pkg/config/cooldown_test.go
+++ b/pkg/config/cooldown_test.go
@@ -1,0 +1,93 @@
+package config
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseCooldown(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    time.Duration
+		wantErr bool
+	}{
+		{"", 0, false},
+		{"0", 0, false},
+		{" 0 ", 0, false},
+		{"24h", 24 * time.Hour, false},
+		{"90m", 90 * time.Minute, false},
+		{"1h30m", 90 * time.Minute, false},
+		{"1d", 24 * time.Hour, false},
+		{"7d", 7 * 24 * time.Hour, false},
+		{"2w", 14 * 24 * time.Hour, false},
+		{"abc", 0, true},
+		{"-1d", 0, true},
+		{"-5h", 0, true},
+		{"5x", 0, true},
+	}
+
+	for _, c := range cases {
+		got, err := ParseCooldown(c.in)
+		if c.wantErr {
+			if err == nil {
+				t.Errorf("ParseCooldown(%q): expected error, got %v", c.in, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("ParseCooldown(%q): unexpected error %v", c.in, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("ParseCooldown(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestFormatCooldown(t *testing.T) {
+	cases := []struct {
+		in   time.Duration
+		want string
+	}{
+		{0, "disabled"},
+		{-1, "disabled"},
+		{24 * time.Hour, "1d"},
+		{7 * 24 * time.Hour, "1w"},
+		{14 * 24 * time.Hour, "2w"},
+		{48 * time.Hour, "2d"},
+		{90 * time.Minute, "1h30m0s"},
+	}
+	for _, c := range cases {
+		if got := FormatCooldown(c.in); got != c.want {
+			t.Errorf("FormatCooldown(%v) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestEffectiveCooldown(t *testing.T) {
+	// Save and restore the package singleton.
+	orig := cfg
+	t.Cleanup(func() { cfg = orig })
+
+	// No default, no override -> built-in default (0/disabled).
+	cfg = config{}
+	if d, err := EffectiveCooldown(nil); err != nil || d != builtinDefaultCooldown {
+		t.Fatalf("nil binary, no default: got (%v, %v), want (%v, nil)", d, err, builtinDefaultCooldown)
+	}
+
+	// Global default applies when no per-binary override is set.
+	cfg = config{DefaultCooldown: "24h"}
+	if d, err := EffectiveCooldown(&Binary{}); err != nil || d != 24*time.Hour {
+		t.Fatalf("default only: got (%v, %v), want (24h, nil)", d, err)
+	}
+
+	// Per-binary override beats the global default.
+	if d, err := EffectiveCooldown(&Binary{Cooldown: "7d"}); err != nil || d != 7*24*time.Hour {
+		t.Fatalf("override: got (%v, %v), want (168h, nil)", d, err)
+	}
+
+	// An explicit "0" override disables cooldown even when a default is set.
+	if d, err := EffectiveCooldown(&Binary{Cooldown: "0"}); err != nil || d != 0 {
+		t.Fatalf("override disable: got (%v, %v), want (0, nil)", d, err)
+	}
+}

--- a/pkg/providers/codeberg.go
+++ b/pkg/providers/codeberg.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	"code.gitea.io/sdk/gitea"
 	"github.com/caarlos0/log"
@@ -79,14 +80,18 @@ func (c *codeberg) Fetch(opts *FetchOpts) (*File, error) {
 
 // GetLatestVersion checks the latest repo release and
 // returns the corresponding name and url to fetch the version
-func (c *codeberg) GetLatestVersion() (string, string, error) {
+func (c *codeberg) GetLatestVersion() (string, string, time.Time, error) {
 	log.Debugf("Getting latest release for %s/%s", c.owner, c.repo)
 	release, _, err := c.client.GetLatestRelease(c.owner, c.repo)
 	if err != nil {
-		return "", "", err
+		return "", "", time.Time{}, err
 	}
 
-	return release.TagName, release.HTMLURL, nil
+	published := release.PublishedAt
+	if published.IsZero() {
+		published = release.CreatedAt
+	}
+	return release.TagName, release.HTMLURL, published, nil
 }
 
 func (c *codeberg) GetID() string {

--- a/pkg/providers/docker.go
+++ b/pkg/providers/docker.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/caarlos0/log"
 	"github.com/docker/docker/api/types/image"
@@ -47,8 +48,10 @@ func (d *docker) Fetch(opts *FetchOpts) (*File, error) {
 }
 
 // TODO: missing implementation here
-func (d *docker) GetLatestVersion() (string, string, error) {
-	return d.tag, "", nil
+func (d *docker) GetLatestVersion() (string, string, time.Time, error) {
+	// A docker tag has no meaningful publish date here, so cooldowns are not
+	// enforced for docker binaries.
+	return d.tag, "", time.Time{}, nil
 }
 
 func (d *docker) GetID() string {

--- a/pkg/providers/github.go
+++ b/pkg/providers/github.go
@@ -110,7 +110,7 @@ func (g *gitHub) GetLatestVersion() (string, string, time.Time, error) {
 // releasePublishedAt returns the release's published time, falling back to its
 // creation time when the published time is not set.
 func releasePublishedAt(r *github.RepositoryRelease) time.Time {
-	if t := r.GetPublishedAt(); !t.Time.IsZero() {
+	if t := r.GetPublishedAt(); !t.IsZero() {
 		return t.Time
 	}
 	return r.GetCreatedAt().Time

--- a/pkg/providers/github.go
+++ b/pkg/providers/github.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/caarlos0/log"
 	"github.com/google/go-github/v31/github"
@@ -87,23 +88,32 @@ func (g *gitHub) Fetch(opts *FetchOpts) (*File, error) {
 
 // GetLatestVersion checks the latest repo release and
 // returns the corresponding name and url to fetch the version
-func (g *gitHub) GetLatestVersion() (string, string, error) {
+func (g *gitHub) GetLatestVersion() (string, string, time.Time, error) {
 	if g.filter != "" {
 		log.Debugf("Getting latest release matching %q for %s/%s", g.filter, g.owner, g.repo)
 		release, err := g.findLatestMatchingRelease()
 		if err != nil {
-			return "", "", err
+			return "", "", time.Time{}, err
 		}
-		return release.GetTagName(), release.GetHTMLURL(), nil
+		return release.GetTagName(), release.GetHTMLURL(), releasePublishedAt(release), nil
 	}
 
 	log.Debugf("Getting latest release for %s/%s", g.owner, g.repo)
 	release, _, err := g.client.Repositories.GetLatestRelease(context.TODO(), g.owner, g.repo)
 	if err != nil {
-		return "", "", err
+		return "", "", time.Time{}, err
 	}
 
-	return release.GetTagName(), release.GetHTMLURL(), nil
+	return release.GetTagName(), release.GetHTMLURL(), releasePublishedAt(release), nil
+}
+
+// releasePublishedAt returns the release's published time, falling back to its
+// creation time when the published time is not set.
+func releasePublishedAt(r *github.RepositoryRelease) time.Time {
+	if t := r.GetPublishedAt(); !t.Time.IsZero() {
+		return t.Time
+	}
+	return r.GetCreatedAt().Time
 }
 
 // findLatestMatchingRelease pages through releases and returns the first one

--- a/pkg/providers/gitlab.go
+++ b/pkg/providers/gitlab.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/caarlos0/log"
 	"github.com/coreos/go-semver/semver"
@@ -44,7 +45,7 @@ func (g *gitLab) Fetch(opts *FetchOpts) (*File, error) {
 		// TODO: handle case when repo doesn't have releases?
 		log.Infof("Getting latest release for %s/%s", g.owner, g.repo)
 		var name string
-		name, _, err = g.GetLatestVersion()
+		name, _, _, err = g.GetLatestVersion()
 		if err != nil {
 			return nil, err
 		}
@@ -191,7 +192,7 @@ func (g *gitLab) GetID() string {
 
 // GetLatestVersion checks the latest repo release and
 // returns the corresponding name and url to fetch the version
-func (g *gitLab) GetLatestVersion() (string, string, error) {
+func (g *gitLab) GetLatestVersion() (string, string, time.Time, error) {
 	log.Debugf("Getting latest release for %s/%s", g.owner, g.repo)
 	projectPath := fmt.Sprintf("%s/%s", g.owner, g.repo)
 
@@ -199,10 +200,10 @@ func (g *gitLab) GetLatestVersion() (string, string, error) {
 		ListOptions: gitlab.ListOptions{PerPage: 100},
 	})
 	if err != nil {
-		return "", "", err
+		return "", "", time.Time{}, err
 	}
 	if len(releases) == 0 {
-		return "", "", fmt.Errorf("no releases found for %s/%s", g.owner, g.repo)
+		return "", "", time.Time{}, fmt.Errorf("no releases found for %s/%s", g.owner, g.repo)
 	}
 	highestTagName := releases[0].TagName
 	var svs semver.Versions
@@ -225,7 +226,23 @@ func (g *gitLab) GetLatestVersion() (string, string, error) {
 		highestTagName = svToTagName[svs[len(svs)-1].String()]
 	}
 
-	return highestTagName, tagNameToRelease[highestTagName].Commit.WebURL, nil
+	rel := tagNameToRelease[highestTagName]
+	return highestTagName, rel.Commit.WebURL, gitlabReleaseTime(rel), nil
+}
+
+// gitlabReleaseTime returns the release's published time, preferring ReleasedAt
+// and falling back to CreatedAt. Both are pointers and may be nil.
+func gitlabReleaseTime(r *gitlab.Release) time.Time {
+	if r == nil {
+		return time.Time{}
+	}
+	if r.ReleasedAt != nil {
+		return *r.ReleasedAt
+	}
+	if r.CreatedAt != nil {
+		return *r.CreatedAt
+	}
+	return time.Time{}
 }
 
 func newGitLab(u *url.URL) (Provider, error) {

--- a/pkg/providers/goinstall.go
+++ b/pkg/providers/goinstall.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/caarlos0/log"
 	"github.com/marcosnils/bin/pkg/httpclient"
@@ -64,7 +65,7 @@ func (g *goinstall) Fetch(opts *FetchOpts) (*File, error) {
 		log.Infof("Getting %s release for %s", g.tag, g.repo)
 	} else {
 		log.Infof("Getting latest release for %s", g.repo)
-		if name, _, err := g.GetLatestVersion(); err != nil {
+		if name, _, _, err := g.GetLatestVersion(); err != nil {
 			return nil, fmt.Errorf("failed to get latest version: %w", err)
 		} else {
 			g.tag = name
@@ -96,29 +97,37 @@ func (g *goinstall) Fetch(opts *FetchOpts) (*File, error) {
 	}, nil
 }
 
-func (g *goinstall) GetLatestVersion() (string, string, error) {
+func (g *goinstall) GetLatestVersion() (string, string, time.Time, error) {
 	resp, err := httpclient.Client.Get(g.latestURL)
 	if err != nil {
-		return "", "", err
+		return "", "", time.Time{}, err
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", "", err
+		return "", "", time.Time{}, err
 	}
 
 	var result map[string]interface{}
 	if err := json.Unmarshal(body, &result); err != nil {
-		return "", "", err
+		return "", "", time.Time{}, err
 	}
 
 	version, ok := result["Version"].(string)
 	if !ok {
-		return "", "", fmt.Errorf("version not found in response")
+		return "", "", time.Time{}, fmt.Errorf("version not found in response")
 	}
 
-	return version, g.repo, nil
+	// The go module proxy @latest response includes an RFC3339 "Time" field.
+	var published time.Time
+	if ts, ok := result["Time"].(string); ok {
+		if t, perr := time.Parse(time.RFC3339, ts); perr == nil {
+			published = t
+		}
+	}
+
+	return version, g.repo, published, nil
 }
 
 func (g *goinstall) GetID() string {

--- a/pkg/providers/httprelease.go
+++ b/pkg/providers/httprelease.go
@@ -1,6 +1,8 @@
 package providers
 
 import (
+	"time"
+
 	"github.com/caarlos0/log"
 	"github.com/marcosnils/bin/pkg/assets"
 )
@@ -63,6 +65,9 @@ func (p *httpReleaseProvider) Fetch(opts *FetchOpts) (*File, error) {
 	return &File{Data: outFile.Source, Name: outFile.Name, Version: version, PackagePath: outFile.PackagePath, SelectedAsset: gf.Name}, nil
 }
 
-func (p *httpReleaseProvider) GetLatestVersion() (string, string, error) {
-	return p.src.latestVersion()
+func (p *httpReleaseProvider) GetLatestVersion() (string, string, time.Time, error) {
+	// HTTP release sources (helm, hashicorp) don't expose a publish date, so
+	// cooldowns are not enforced for them.
+	v, u, err := p.src.latestVersion()
+	return v, u, time.Time{}, err
 }

--- a/pkg/providers/providers.go
+++ b/pkg/providers/providers.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
+	"time"
 )
 
 var ErrInvalidProvider = errors.New("invalid provider")
@@ -49,12 +50,28 @@ type Provider interface {
 	// Fetch returns the file metadata to retrieve a specific binary given
 	// for a provider
 	Fetch(*FetchOpts) (*File, error)
-	// GetLatestVersion returns the version and the URL of the
-	// latest version for this binary
-	GetLatestVersion() (string, string, error)
+	// GetLatestVersion returns the version, the URL and the publish time of
+	// the latest version for this binary. Providers that cannot determine a
+	// publish time return the zero time.Time, in which case cooldowns are not
+	// enforced for them.
+	GetLatestVersion() (string, string, time.Time, error)
 
 	// GetID returns the unique identiifer of this provider
 	GetID() string
+}
+
+// SupportsPublishDate reports whether the provider identified by id exposes a
+// publish date for its releases. When false, cooldowns cannot be enforced for
+// binaries installed with that provider (GetLatestVersion returns the zero
+// time). This is a static lookup so callers (e.g. `bin ls`) can label
+// enforceability without performing a network request.
+func SupportsPublishDate(id string) bool {
+	switch id {
+	case "github", "gitlab", "codeberg", "goinstall":
+		return true
+	default:
+		return false
+	}
 }
 
 var (


### PR DESCRIPTION
Add a supply-chain hardening feature that delays updating a binary until a configurable cooldown has elapsed since the target version was published, giving the community time to detect malicious releases.

- config: `DefaultCooldown` (global) and per-Binary `Cooldown` fields, plus ParseCooldown/FormatCooldown/EffectiveCooldown/SetDefaultCooldown helpers supporting a friendly duration format (24h, 90m, 7d, 2w).
- providers: extend `GetLatestVersion` to return the release publish time; GitHub/GitLab/Codeberg/goinstall supply real dates, others return zero. Add SupportsPublishDate for static enforceability checks.
- update: skip versions published more recently than the effective cooldown; unknown (zero) publish dates are never gated.
- cmd: new `bin cooldown` command with get/set/unset/list subcommands for the default and per-package cooldowns.
- list: show a `Cooldown` column in `bin ls` (- disabled, n/a unenforceable, value with * for per-package override).
- tests + README docs.

Cooldowns are opt-in (disabled by default) so upgrading never silently blocks updates.

Closes #284 