### PR TITLE
test(providers): add unit tests for provider routing and URL parsing

### DIFF
--- a/pkg/providers/codeberg_test.go
+++ b/pkg/providers/codeberg_test.go
@@ -1,0 +1,56 @@
+package providers
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestNewCodeberg(t *testing.T) {
+	cases := []struct {
+		name          string
+		rawURL        string
+		expectedOwner string
+		expectedRepo  string
+		expectedTag   string
+		wantErr       bool
+	}{
+		{name: "owner/repo", rawURL: "https://codeberg.org/owner/repo", expectedOwner: "owner", expectedRepo: "repo"},
+		{name: "releases tag", rawURL: "https://codeberg.org/owner/repo/releases/tag/v1.0", expectedOwner: "owner", expectedRepo: "repo", expectedTag: "v1.0"},
+		{name: "too few segments", rawURL: "https://codeberg.org/owner", wantErr: true},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			u, err := url.Parse(test.rawURL)
+			if err != nil {
+				t.Fatalf("url.Parse failed: %v", err)
+			}
+			p, err := newCodeberg(u)
+			if test.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Skipf("codeberg client requires network: %v", err)
+			}
+			cb, ok := p.(*codeberg)
+			if !ok {
+				t.Fatalf("expected *codeberg, got %T", p)
+			}
+			if cb.owner != test.expectedOwner {
+				t.Errorf("expected owner %q, got %q", test.expectedOwner, cb.owner)
+			}
+			if cb.repo != test.expectedRepo {
+				t.Errorf("expected repo %q, got %q", test.expectedRepo, cb.repo)
+			}
+			if cb.tag != test.expectedTag {
+				t.Errorf("expected tag %q, got %q", test.expectedTag, cb.tag)
+			}
+			if cb.GetID() != "codeberg" {
+				t.Errorf("expected id codeberg, got %s", cb.GetID())
+			}
+		})
+	}
+}

--- a/pkg/providers/github_test.go
+++ b/pkg/providers/github_test.go
@@ -1,0 +1,68 @@
+package providers
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestNewGitHub(t *testing.T) {
+	cases := []struct {
+		name          string
+		rawURL        string
+		expectedOwner string
+		expectedRepo  string
+		expectedTag   string
+		expectFilter  string
+		wantErr       bool
+	}{
+		{name: "owner/repo", rawURL: "https://github.com/owner/repo", expectedOwner: "owner", expectedRepo: "repo"},
+		{name: "releases tag", rawURL: "https://github.com/owner/repo/releases/tag/v1.0", expectedOwner: "owner", expectedRepo: "repo", expectedTag: "v1.0"},
+		{name: "releases download", rawURL: "https://github.com/owner/repo/releases/download/v1.0", expectedOwner: "owner", expectedRepo: "repo", expectedTag: "v1.0"},
+		{name: "filter", rawURL: "https://github.com/owner/repo?filter=*.tar.gz", expectedOwner: "owner", expectedRepo: "repo", expectFilter: "*.tar.gz"},
+		{name: "invalid filter", rawURL: "https://github.com/owner/repo?filter=%5B", wantErr: true},
+		{name: "too few segments", rawURL: "https://github.com/owner", wantErr: true},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			u, err := url.Parse(test.rawURL)
+			if err != nil {
+				t.Fatalf("url.Parse failed: %v", err)
+			}
+			p, err := newGitHub(u)
+			if test.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			gh, ok := p.(*gitHub)
+			if !ok {
+				t.Fatalf("expected *gitHub, got %T", p)
+			}
+			if gh.owner != test.expectedOwner {
+				t.Errorf("expected owner %q, got %q", test.expectedOwner, gh.owner)
+			}
+			if gh.repo != test.expectedRepo {
+				t.Errorf("expected repo %q, got %q", test.expectedRepo, gh.repo)
+			}
+			if gh.tag != test.expectedTag {
+				t.Errorf("expected tag %q, got %q", test.expectedTag, gh.tag)
+			}
+			if gh.filter != test.expectFilter {
+				t.Errorf("expected filter %q, got %q", test.expectFilter, gh.filter)
+			}
+			if test.expectFilter != "" {
+				if gh.url.RawQuery != "" && gh.url.Query().Get("filter") != "" {
+					t.Errorf("expected filter removed from query, got %q", gh.url.RawQuery)
+				}
+			}
+			if gh.GetID() != "github" {
+				t.Errorf("expected id github, got %s", gh.GetID())
+			}
+		})
+	}
+}

--- a/pkg/providers/gitlab_test.go
+++ b/pkg/providers/gitlab_test.go
@@ -1,0 +1,56 @@
+package providers
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestNewGitLab(t *testing.T) {
+	cases := []struct {
+		name          string
+		rawURL        string
+		expectedOwner string
+		expectedRepo  string
+		expectedTag   string
+		wantErr       bool
+	}{
+		{name: "owner/repo", rawURL: "https://gitlab.com/owner/repo", expectedOwner: "owner", expectedRepo: "repo"},
+		{name: "releases tag", rawURL: "https://gitlab.com/owner/repo/releases/v1.0", expectedOwner: "owner", expectedRepo: "repo", expectedTag: "v1.0"},
+		{name: "too few segments", rawURL: "https://gitlab.com/owner", wantErr: true},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			u, err := url.Parse(test.rawURL)
+			if err != nil {
+				t.Fatalf("url.Parse failed: %v", err)
+			}
+			p, err := newGitLab(u)
+			if test.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			gl, ok := p.(*gitLab)
+			if !ok {
+				t.Fatalf("expected *gitLab, got %T", p)
+			}
+			if gl.owner != test.expectedOwner {
+				t.Errorf("expected owner %q, got %q", test.expectedOwner, gl.owner)
+			}
+			if gl.repo != test.expectedRepo {
+				t.Errorf("expected repo %q, got %q", test.expectedRepo, gl.repo)
+			}
+			if gl.tag != test.expectedTag {
+				t.Errorf("expected tag %q, got %q", test.expectedTag, gl.tag)
+			}
+			if gl.GetID() != "gitlab" {
+				t.Errorf("expected id gitlab, got %s", gl.GetID())
+			}
+		})
+	}
+}

--- a/pkg/providers/goinstall_test.go
+++ b/pkg/providers/goinstall_test.go
@@ -1,0 +1,82 @@
+package providers
+
+import (
+	"testing"
+)
+
+func TestParseRepo(t *testing.T) {
+	cases := []struct {
+		name              string
+		path              string
+		expectedRepo      string
+		expectedTag       string
+		expectedName      string
+		expectedLatestURL string
+	}{
+		{
+			name:              "no tag",
+			path:              "github.com/foo/bar",
+			expectedRepo:      "github.com/foo/bar",
+			expectedTag:       "latest",
+			expectedName:      "bar",
+			expectedLatestURL: "https://proxy.golang.org/github.com/foo/bar/@latest",
+		},
+		{
+			name:              "with tag",
+			path:              "github.com/foo/bar@v1.2.3",
+			expectedRepo:      "github.com/foo/bar",
+			expectedTag:       "v1.2.3",
+			expectedName:      "bar",
+			expectedLatestURL: "https://proxy.golang.org/github.com/foo/bar/@latest",
+		},
+		{
+			name:              "subpackage with tag",
+			path:              "github.com/foo/bar/cmd/baz@v1.0",
+			expectedRepo:      "github.com/foo/bar/cmd/baz",
+			expectedTag:       "v1.0",
+			expectedName:      "baz",
+			expectedLatestURL: "https://proxy.golang.org/github.com/foo/bar/cmd/baz/@latest",
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			repo, tag, name, latestURL := parseRepo(test.path)
+			if repo != test.expectedRepo {
+				t.Errorf("expected repo %q, got %q", test.expectedRepo, repo)
+			}
+			if tag != test.expectedTag {
+				t.Errorf("expected tag %q, got %q", test.expectedTag, tag)
+			}
+			if name != test.expectedName {
+				t.Errorf("expected name %q, got %q", test.expectedName, name)
+			}
+			if latestURL != test.expectedLatestURL {
+				t.Errorf("expected latestURL %q, got %q", test.expectedLatestURL, latestURL)
+			}
+		})
+	}
+}
+
+func TestNewGoInstall(t *testing.T) {
+	p, err := newGoInstall("goinstall://github.com/foo/bar@v1.0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	gi, ok := p.(*goinstall)
+	if !ok {
+		t.Fatalf("expected *goinstall, got %T", p)
+	}
+	if gi.repo != "github.com/foo/bar" {
+		t.Errorf("expected repo github.com/foo/bar, got %q", gi.repo)
+	}
+	if gi.tag != "v1.0" {
+		t.Errorf("expected tag v1.0, got %q", gi.tag)
+	}
+	if gi.name != "bar" {
+		t.Errorf("expected name bar, got %q", gi.name)
+	}
+	if gi.GetID() != "goinstall" {
+		t.Errorf("expected id goinstall, got %s", gi.GetID())
+	}
+}

--- a/pkg/providers/providers_test.go
+++ b/pkg/providers/providers_test.go
@@ -1,0 +1,48 @@
+package providers
+
+import (
+	"testing"
+)
+
+func TestNew(t *testing.T) {
+	cases := []struct {
+		name       string
+		u          string
+		provider   string
+		expectedID string
+		wantErr    bool
+		mayNetwork bool
+	}{
+		{name: "docker", u: "docker://postgres:1.2.3", expectedID: "docker"},
+		{name: "goinstall scheme", u: "goinstall://github.com/foo/bar@v1.0", expectedID: "goinstall"},
+		{name: "goinstall hint", u: "github.com/foo/bar@v1.0", provider: "goinstall", expectedID: "goinstall"},
+		{name: "github bare host", u: "github.com/owner/repo", expectedID: "github"},
+		{name: "github https", u: "https://github.com/owner/repo", expectedID: "github"},
+		{name: "github hint", u: "example.com/owner/repo", provider: "github", expectedID: "github"},
+		{name: "gitlab host", u: "gitlab.com/owner/repo", expectedID: "gitlab"},
+		{name: "gitlab hint", u: "example.com/owner/repo", provider: "gitlab", expectedID: "gitlab"},
+		{name: "codeberg host", u: "codeberg.org/owner/repo", expectedID: "codeberg", mayNetwork: true},
+		{name: "unknown host", u: "example.com/owner/repo", wantErr: true},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			p, err := New(test.u, test.provider)
+			if test.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil (provider=%v)", p)
+				}
+				return
+			}
+			if err != nil {
+				if test.mayNetwork {
+					t.Skipf("%s client requires network: %v", test.name, err)
+				}
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if p.GetID() != test.expectedID {
+				t.Errorf("expected id %s, got %s", test.expectedID, p.GetID())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

This PR adds comprehensive unit tests for the `providers` package, specifically targeting the provider routing logic and URL parsing functions that previously had no test coverage.

## What's tested

| File | What it tests |
|------|--------------|
| `providers_test.go` | `New()` function — URL-to-provider routing for all provider types |
| `github_test.go` | `newGitHub()` — GitHub URL parsing (owner, repo, tag, filter extraction) |
| `gitlab_test.go` | `newGitLab()` — GitLab URL parsing (different tag extraction logic) |
| `codeberg_test.go` | `newCodeberg()` — Codeberg/Gitea URL parsing |
| `goinstall_test.go` | `parseRepo()` — Go install path parsing |

## Approach

- Table-driven tests following Go conventions
- Tests cover both happy paths and error cases
- No changes to existing source code
- Existing test files (docker, hashicorp, helm) are untouched

## Test results

All tests pass with `go test ./pkg/providers/... -v`